### PR TITLE
Collect File Timestamps from disk when available

### DIFF
--- a/RecursiveExtractor.Blazor/RecursiveExtractor.Blazor.csproj
+++ b/RecursiveExtractor.Blazor/RecursiveExtractor.Blazor.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.177" />
-    <PackageReference Include="System.Net.Http.Json" Version="3.2.0" />
-    <PackageReference Include="Tewr.Blazor.FileReader" Version="2.0.0.20200" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.5" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.221" />
+    <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
+    <PackageReference Include="Tewr.Blazor.FileReader" Version="3.0.0.20340" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,6 +26,10 @@
     <Content Update="Pages\Index.razor">
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
     </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
   </ItemGroup>
 
 </Project>

--- a/RecursiveExtractor.Blazor/Shared/DragnDropInputCommon.razor
+++ b/RecursiveExtractor.Blazor/Shared/DragnDropInputCommon.razor
@@ -4,7 +4,7 @@
 @inject Microsoft.CST.RecursiveExtractor.Blazor.Services.AppData appData;
 
 <style>
-    .@dropTargetClass {
+    .droptarget {
         display: block;
         padding: 20px;
         margin-bottom: 10px;
@@ -13,7 +13,7 @@
         position: relative;
     }
 
-    .@dropTargetDragClass {
+    .droptarget-drag {
         border-color: orangered;
         font-weight: bold;
     }

--- a/RecursiveExtractor.Cli/RecursiveExtractor.Cli.csproj
+++ b/RecursiveExtractor.Cli/RecursiveExtractor.Cli.csproj
@@ -29,11 +29,15 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.4" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.2" />
   </ItemGroup>
  
   <ItemGroup>
     <None Include="..\LICENSE.txt" Pack="true" PackagePath="" />
     <None Include="..\icon-128.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+ 
+  <ItemGroup>
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
   </ItemGroup>  
 </Project>

--- a/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
+++ b/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
@@ -15,15 +15,11 @@
     <PackageReference Include="DiscUtils.HfsPlus" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.SquashFs" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0-preview-20200428-01" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="NLog.Extensions.Logging" Version="1.6.4" />
-    <PackageReference Include="Sarif.Sdk" Version="2.2.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="1.7.2" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.7" />
   </ItemGroup>
 
   <ItemGroup>
@@ -270,6 +266,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
   </ItemGroup>
 </Project>

--- a/RecursiveExtractor/RecursiveExtractor.csproj
+++ b/RecursiveExtractor/RecursiveExtractor.csproj
@@ -38,10 +38,13 @@
     <PackageReference Include="DiscUtils.Wim" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="NLog" Version="4.7.8" />
-    <PackageReference Include="SharpCompress" Version="0.28.1" />
+    <PackageReference Include="NLog" Version="4.7.9" />
+    <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.1" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.3.37" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.194">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When you call extract with a path to extract we will now grab the access time information and store it in the file entry object that is returned.