### PR TITLE
Adds AllowDeny Glob filtering to the actual extraction

### DIFF
--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -12,11 +12,11 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
     public static class RecursiveExtractorClient
     {
 		public static int Main(string[] args)
-		{            
+		{  
             return CommandLine.Parser.Default.ParseArguments<ExtractCommandOptions>(args)
 			  .MapResult(
 				(ExtractCommandOptions opts) => ExtractCommand(opts),
-				errs => 1);
+				_ => 1);
 		}
 
         public static int ExtractCommand(ExtractCommandOptions options)
@@ -65,6 +65,6 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
 
             return 0;
         }
-        private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+        private readonly static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
     }
 }

--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -12,7 +12,7 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
     public static class RecursiveExtractorClient
     {
 		public static int Main(string[] args)
-		{  
+		{
             return CommandLine.Parser.Default.ParseArguments<ExtractCommandOptions>(args)
 			  .MapResult(
 				(ExtractCommandOptions opts) => ExtractCommand(opts),

--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -9,7 +9,7 @@ using NLog.Config;
 using NLog.Targets;
 namespace Microsoft.CST.RecursiveExtractor.Cli
 {
-    public class RecursiveExtractorClient
+    public static class RecursiveExtractorClient
     {
 		public static int Main(string[] args)
 		{            
@@ -47,7 +47,7 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
             {
                 ExtractSelfOnFail = true,
                 Parallel = true,
-                RawExtensions = options.RawExtensions
+                RawExtensions = options.RawExtensions ?? Array.Empty<string>()
             };
             if (options.Passwords?.Any() ?? false)
             {

--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -70,7 +70,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
             var extractor = new Extractor();
-            Assert.AreEqual(ExtractionStatusCode.Ok, await extractor.ExtractToDirectoryAsync(directory, path));
+            Assert.AreEqual(ExtractionStatusCode.Ok, await extractor.ExtractToDirectoryAsync(directory, path).ConfigureAwait(false));
             var files = Array.Empty<string>();
             if (Directory.Exists(directory))
             {
@@ -290,7 +290,6 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             Assert.AreEqual(expectedNumFiles, numResults);
         }
 
-
         [DataRow("TextFile.md")]
         [DataRow("Nested.zip", ".zip")]
         public void ExtractAsRaw(string fileName, string? RawExtension)
@@ -306,7 +305,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             Assert.AreEqual(1, results.Count());
         }
 
-        public static Dictionary<Regex, List<string>> TestArchivePasswords = new Dictionary<Regex, List<string>>()
+        public static Dictionary<Regex, List<string>> TestArchivePasswords { get; } = new Dictionary<Regex, List<string>>()
         {
             {
                 new Regex("EncryptedZipCrypto.zip"),

--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -106,6 +106,31 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         }
 
         [DataTestMethod]
+        [DataRow("TestData.zip", 5)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 5)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 5)]
+        [DataRow("TestData.tar.gz", 5)]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 8)]
+        [DataRow("TestData.a")]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 51)]
+        public void ExtractArchiveParallel(string fileName, int expectedNumFiles = 3)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { Parallel = true });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
         [DataRow("TestData.zip")]
         [DataRow("TestData.7z")]
         [DataRow("TestData.tar")]
@@ -386,31 +411,6 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
                 numFound++;
             }
             Assert.AreEqual(expectedNumFiles, numFound);
-        }
-
-        [DataTestMethod]
-        [DataRow("TestData.zip", 5)]
-        [DataRow("TestData.7z")]
-        [DataRow("TestData.tar", 5)]
-        [DataRow("TestData.rar")]
-        [DataRow("TestData.rar4")]
-        [DataRow("TestData.tar.bz2", 5)]
-        [DataRow("TestData.tar.gz", 5)]
-        [DataRow("TestData.tar.xz")]
-        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 8)]
-        [DataRow("TestData.a")]
-        //[DataRow("TestData.ar")]
-        [DataRow("TestData.iso")]
-        [DataRow("TestData.vhdx")]
-        [DataRow("TestData.wim")]
-        [DataRow("EmptyFile.txt", 1)]
-        [DataRow("TestDataArchivesNested.Zip", 51)]
-        public void ExtractArchiveParallel(string fileName, int expectedNumFiles = 3)
-        {
-            var extractor = new Extractor();
-            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
-            var results = extractor.Extract(path, new ExtractorOptions() { Parallel = true });
-            Assert.AreEqual(expectedNumFiles, results.Count());
         }
 
         [DataTestMethod]

--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -298,7 +298,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             var extractor = new Extractor();
             var options = new ExtractorOptions()
             {
-                RawExtensions = RawExtension is null ? null : new List<string>(){ RawExtension }
+                RawExtensions = RawExtension is null ? new List<string>():new List<string>(){ RawExtension }
             };
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
 

--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -105,7 +105,117 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             Assert.AreEqual(expectedNumFiles, results.Count());
         }
 
-                
+        [DataTestMethod]
+        [DataRow("TestData.zip")]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar")]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2")]
+        [DataRow("TestData.tar.gz")]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 0)]
+        [DataRow("TestData.a", 0)]
+        [DataRow("TestData.ar", 0)]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 0)]
+        [DataRow("TestDataArchivesNested.Zip", 1)]
+        public async Task ExtractArchiveAsyncAllowFiltered(string fileName, int expectedNumFiles = 1)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.ExtractAsync(path, new ExtractorOptions() { AllowFilters = new string[] { "**/Bar/**", "**/TestData.tar" } });
+            var numResults = 0;
+            await foreach(var result in results)
+            {
+                numResults++;
+            }
+            Assert.AreEqual(expectedNumFiles, numResults);
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip")]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar")]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2")]
+        [DataRow("TestData.tar.gz")]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb",0)]
+        [DataRow("TestData.a",0)]
+        [DataRow("TestData.ar",0)]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 0)]
+        [DataRow("TestDataArchivesNested.Zip", 1)]
+        public void ExtractArchiveAllowFiltered(string fileName, int expectedNumFiles = 1)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { AllowFilters = new string[] { "**/Bar/**", "**/TestData.tar" } });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip", 4)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 4)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 4)]
+        [DataRow("TestData.tar.gz", 4)]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 8)]
+        [DataRow("TestData.a", 3)]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 42)]
+        public void ExtractArchiveDenyFiltered(string fileName, int expectedNumFiles = 2)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { DenyFilters = new string[] { "**/Bar/**" } });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip", 4)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 4)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 4)]
+        [DataRow("TestData.tar.gz", 4)]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 8)]
+        [DataRow("TestData.a", 3)]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 42)]
+        public async Task ExtractArchiveAsyncDenyFiltered(string fileName, int expectedNumFiles = 2)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.ExtractAsync(path, new ExtractorOptions() { DenyFilters = new string[] { "**/Bar/**" } });
+            var numResults = 0;
+            await foreach (var result in results)
+            {
+                numResults++;
+            }
+            Assert.AreEqual(expectedNumFiles, numResults);
+        }
+
+
         [DataRow("TextFile.md")]
         [DataRow("Nested.zip", ".zip")]
         public void ExtractAsRaw(string fileName, string? RawExtension)

--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -161,6 +161,31 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         }
 
         [DataTestMethod]
+        [DataRow("TestData.zip")]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar")]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2")]
+        [DataRow("TestData.tar.gz")]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 0)]
+        [DataRow("TestData.a", 0)]
+        [DataRow("TestData.ar", 0)]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 0)]
+        [DataRow("TestDataArchivesNested.Zip", 1)]
+        public void ExtractArchiveParallelAllowFiltered(string fileName, int expectedNumFiles = 1)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { Parallel = true, AllowFilters = new string[] { "**/Bar/**", "**/TestData.tar" } });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
         [DataRow("TestData.zip", 4)]
         [DataRow("TestData.7z")]
         [DataRow("TestData.tar", 4)]
@@ -182,6 +207,31 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             var extractor = new Extractor();
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
             var results = extractor.Extract(path, new ExtractorOptions() { DenyFilters = new string[] { "**/Bar/**" } });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip", 4)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 4)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 4)]
+        [DataRow("TestData.tar.gz", 4)]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 8)]
+        [DataRow("TestData.a", 3)]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 42)]
+        public void ExtractArchiveParallelDenyFiltered(string fileName, int expectedNumFiles = 2)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { Parallel = true, DenyFilters = new string[] { "**/Bar/**" } });
             Assert.AreEqual(expectedNumFiles, results.Count());
         }
 

--- a/RecursiveExtractor/ArFile.cs
+++ b/RecursiveExtractor/ArFile.cs
@@ -8,7 +8,6 @@ using System.Threading.Tasks;
 
 namespace Microsoft.CST.RecursiveExtractor
 {
-
     /// <summary>
     ///  Ar file parser.  Supports SystemV style lookup tables in both 32 and 64 bit mode as well as BSD and GNU formatted .ars.
     /// </summary>
@@ -31,13 +30,8 @@ namespace Microsoft.CST.RecursiveExtractor
             fileEntry.Content.Position = 8;
             var filenameLookup = new Dictionary<int, string>();
             var headerBuffer = new byte[60];
-            while (true)
+            while (fileEntry.Content.Length - fileEntry.Content.Position >= 60)
             {
-                if (fileEntry.Content.Length - fileEntry.Content.Position < 60)  // The header for each file is 60 bytes
-                {
-                    break;
-                }
-
                 fileEntry.Content.Read(headerBuffer, 0, 60);
                 var headerString = Encoding.ASCII.GetString(headerBuffer);
                 if (long.TryParse(Encoding.ASCII.GetString(headerBuffer[48..58]), out var size))// header size in bytes
@@ -77,7 +71,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     else if (filename.StartsWith("#1/"))
                     {
                         // We should be positioned right after the header
-                        if (int.TryParse(filename.Substring(3), out var nameLength))
+                        if (int.TryParse(filename[3..], out var nameLength))
                         {
                             var nameSpan = new byte[nameLength];
                             // This should move us right to the file
@@ -312,13 +306,8 @@ namespace Microsoft.CST.RecursiveExtractor
             fileEntry.Content.Position = 8;
             var filenameLookup = new Dictionary<int, string>();
             var headerBuffer = new byte[60];
-            while (true)
+            while (fileEntry.Content.Length - fileEntry.Content.Position >= 60)
             {
-                if (fileEntry.Content.Length - fileEntry.Content.Position < 60)  // The header for each file is 60 bytes
-                {
-                    break;
-                }
-
                 fileEntry.Content.Read(headerBuffer, 0, 60);
                 var headerString = Encoding.ASCII.GetString(headerBuffer);
                 if (long.TryParse(Encoding.ASCII.GetString(headerBuffer[48..58]), out var size))// header size in bytes
@@ -333,7 +322,7 @@ namespace Microsoft.CST.RecursiveExtractor
                         // This should just be a list of names, size should be safe to load in memory and cast
                         // to int
                         var fileNamesBytes = new byte[size];
-                        await fileEntry.Content.ReadAsync(fileNamesBytes, 0, (int)size);
+                        await fileEntry.Content.ReadAsync(fileNamesBytes, 0, (int)size).ConfigureAwait(false);
 
                         var name = new StringBuilder();
                         var index = 0;
@@ -358,17 +347,17 @@ namespace Microsoft.CST.RecursiveExtractor
                     else if (filename.StartsWith("#1/"))
                     {
                         // We should be positioned right after the header
-                        if (int.TryParse(filename.Substring(3), out var nameLength))
+                        if (int.TryParse(filename[3..], out var nameLength))
                         {
                             var nameSpan = new byte[nameLength];
                             // This should move us right to the file
-                            await fileEntry.Content.ReadAsync(nameSpan, 0, nameLength);
+                            await fileEntry.Content.ReadAsync(nameSpan, 0, nameLength).ConfigureAwait(false);
 
                             var entryStream = size - nameLength > options.MemoryStreamCutoff ?
                                                                 new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                                                 (Stream)new MemoryStream((int)size - nameLength);
                             // The name length is included in the total size reported in the header
-                            await CopyStreamBytesAsync(fileEntry.Content, entryStream, size - nameLength);
+                            await CopyStreamBytesAsync(fileEntry.Content, entryStream, size - nameLength).ConfigureAwait(false);
 
                             var entry = new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true);
                             if (options.FileNamePasses(entry.FullPath))
@@ -415,7 +404,7 @@ namespace Microsoft.CST.RecursiveExtractor
                         foreach (var entry in fileEntries)
                         {
                             fileEntry.Content.Position = entry.Item1;
-                            await fileEntry.Content.ReadAsync(headerBuffer, 0, 60);
+                            await fileEntry.Content.ReadAsync(headerBuffer, 0, 60).ConfigureAwait(false);
 
                             if (long.TryParse(Encoding.ASCII.GetString(headerBuffer[48..58]), out var innerSize))// header size in bytes
                             {
@@ -440,7 +429,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                 var entryStream = innerSize > options.MemoryStreamCutoff ?
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
-                                await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize);
+                                await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize).ConfigureAwait(false);
                                 var entry2 = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                                 if (options.FileNamePasses(entry2.FullPath))
                                 {
@@ -555,7 +544,7 @@ namespace Microsoft.CST.RecursiveExtractor
                         var entryStream = size > options.MemoryStreamCutoff ?
                             new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
-                        await CopyStreamBytesAsync(fileEntry.Content, entryStream, size);
+                        await CopyStreamBytesAsync(fileEntry.Content, entryStream, size).ConfigureAwait(false);
                         var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                         if (options.FileNamePasses(entry.FullPath))
                         {
@@ -618,10 +607,10 @@ namespace Microsoft.CST.RecursiveExtractor
             long read;
             long totalRead = 0;
             while (bytes > 0 &&
-                   (read = await input.ReadAsync(buffer, 0, (int)Math.Min(buffer.Length, bytes))) > 0)
+                   (read = await input.ReadAsync(buffer, 0, (int)Math.Min(buffer.Length, bytes)).ConfigureAwait(false)) > 0)
             {
                 totalRead += read;
-                await output.WriteAsync(buffer, 0, (int)read);
+                await output.WriteAsync(buffer, 0, (int)read).ConfigureAwait(false);
                 bytes -= read;
             }
             return totalRead;
@@ -629,6 +618,6 @@ namespace Microsoft.CST.RecursiveExtractor
 
         private const int bufferSize = 4096;
 
-        private static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+        private readonly static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
     }
 }

--- a/RecursiveExtractor/ArFile.cs
+++ b/RecursiveExtractor/ArFile.cs
@@ -89,7 +89,11 @@ namespace Microsoft.CST.RecursiveExtractor
                             // The name length is included in the total size reported in the header
                             CopyStreamBytes(fileEntry.Content, entryStream, size - nameLength);
 
-                            yield return new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
+                            var entry = new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
+                            if (options.FileNamePasses(entry.FullPath))
+                            {
+                                yield return entry;
+                            }
                         }
                     }
                     else if (filename.Equals('/'))
@@ -156,7 +160,11 @@ namespace Microsoft.CST.RecursiveExtractor
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 CopyStreamBytes(fileEntry.Content, entryStream, innerSize);
-                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                var entry2 = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                if (options.FileNamePasses(entry2.FullPath))
+                                {
+                                    yield return entry2;
+                                }
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -229,7 +237,11 @@ namespace Microsoft.CST.RecursiveExtractor
                                     (Stream)new MemoryStream((int)innerSize);
                                 CopyStreamBytes(fileEntry.Content, entryStream, innerSize);
 
-                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                if (options.FileNamePasses(entry.FullPath))
+                                {
+                                    yield return entry;
+                                }
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -252,7 +264,11 @@ namespace Microsoft.CST.RecursiveExtractor
                                     (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
 
-                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        if (options.FileNamePasses(entry.FullPath))
+                        {
+                            yield return entry;
+                        }
                     }
                     else
                     {
@@ -261,7 +277,11 @@ namespace Microsoft.CST.RecursiveExtractor
                                     (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
 
-                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        if (options.FileNamePasses(entry.FullPath))
+                        {
+                            yield return entry;
+                        }
                     }
                 }
                 else
@@ -350,7 +370,11 @@ namespace Microsoft.CST.RecursiveExtractor
                             // The name length is included in the total size reported in the header
                             await CopyStreamBytesAsync(fileEntry.Content, entryStream, size - nameLength);
 
-                            yield return new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true);
+                            var entry = new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true);
+                            if (options.FileNamePasses(entry.FullPath))
+                            {
+                                yield return entry;
+                            }
                         }
                     }
                     else if (filename.Equals('/'))
@@ -417,7 +441,11 @@ namespace Microsoft.CST.RecursiveExtractor
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize);
-                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                var entry2 = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                if (options.FileNamePasses(entry2.FullPath))
+                                {
+                                    yield return entry2;
+                                }
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -489,8 +517,12 @@ namespace Microsoft.CST.RecursiveExtractor
                                 var entryStream = innerSize > options.MemoryStreamCutoff ?
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
-                                await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize);
-                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize).ConfigureAwait(false);
+                                var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                                if (options.FileNamePasses(entry.FullPath))
+                                {
+                                    yield return entry;
+                                }
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -512,7 +544,11 @@ namespace Microsoft.CST.RecursiveExtractor
                             new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
-                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        if (options.FileNamePasses(entry.FullPath))
+                        {
+                            yield return entry;
+                        }
                     }
                     else
                     {
@@ -520,8 +556,11 @@ namespace Microsoft.CST.RecursiveExtractor
                             new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
                         await CopyStreamBytesAsync(fileEntry.Content, entryStream, size);
-                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-
+                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
+                        if (options.FileNamePasses(entry.FullPath))
+                        {
+                            yield return entry;
+                        }
                     }
                 }
                 else

--- a/RecursiveExtractor/DebArchiveFile.cs
+++ b/RecursiveExtractor/DebArchiveFile.cs
@@ -90,7 +90,11 @@ namespace Microsoft.CST.RecursiveExtractor
                     var entryContent = new byte[fileSize];
                     await fileEntry.Content.ReadAsync(entryContent, 0, fileSize);
                     var stream = new MemoryStream(entryContent);
-                    yield return new FileEntry(filename, stream, fileEntry, true);
+                    var entry = new FileEntry(filename, stream, fileEntry, true);
+                    if (options.FileNamePasses(entry.FullPath))
+                    {
+                        yield return entry;
+                    }
                 }
                 else
                 {

--- a/RecursiveExtractor/DebArchiveFile.cs
+++ b/RecursiveExtractor/DebArchiveFile.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     governor.CurrentOperationProcessedBytesLeft -= fileSize;
 
                     var entryContent = new byte[fileSize];
-                    await fileEntry.Content.ReadAsync(entryContent, 0, fileSize).ConfigureAwait(false).ConfigureAwait(false);
+                    await fileEntry.Content.ReadAsync(entryContent, 0, fileSize).ConfigureAwait(false);
                     if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{filename}"))
                     {
                         var stream = new MemoryStream(entryContent);

--- a/RecursiveExtractor/DebArchiveFile.cs
+++ b/RecursiveExtractor/DebArchiveFile.cs
@@ -82,7 +82,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     governor.CurrentOperationProcessedBytesLeft -= fileSize;
 
                     var entryContent = new byte[fileSize];
-                    await fileEntry.Content.ReadAsync(entryContent, 0, fileSize).ConfigureAwait(false);
+                    await fileEntry.Content.ReadAsync(entryContent, 0, fileSize).ConfigureAwait(false).ConfigureAwait(false);
                     if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{filename}"))
                     {
                         var stream = new MemoryStream(entryContent);

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -402,16 +402,24 @@ namespace Microsoft.CST.RecursiveExtractor
                 Governor.ResetResourceGovernor(fileEntry.Content);
             }
             Logger.Trace("ExtractFile({0})", fileEntry.FullPath);
+            
             Governor.CurrentOperationProcessedBytesLeft -= fileEntry.Content.Length;
             Governor.CheckResourceGovernor();
+            var type = MiniMagic.DetectFileType(fileEntry);
+
             if (opts?.RawExtensions?.Any(x => Path.GetExtension(fileEntry.FullPath).Equals(x)) ?? false)
             {
-                yield return fileEntry;
+                if (options.FileNamePasses(fileEntry.FullPath))
+                {
+                    yield return fileEntry;
+                }
             }
-            var type = MiniMagic.DetectFileType(fileEntry);
             if (type == ArchiveFileType.UNKNOWN || !Extractors.ContainsKey(type))
             {
-                yield return fileEntry;
+                if (options.FileNamePasses(fileEntry.FullPath))
+                {
+                    yield return fileEntry;
+                }
             }
             else
             {
@@ -635,10 +643,13 @@ namespace Microsoft.CST.RecursiveExtractor
                 if (opts?.RawExtensions?.Any(x => Path.GetExtension(fileEntry.FullPath).Equals(x)) ?? false)
                 {
                     useRaw = true;
-                    result = new[]
+                    if (options.FileNamePasses(fileEntry.FullPath))
                     {
-                        fileEntry
-                    };
+                        result = new[]
+                        {
+                                fileEntry
+                            };
+                    }
                 }
                 else
                 {
@@ -646,10 +657,13 @@ namespace Microsoft.CST.RecursiveExtractor
                     if (type == ArchiveFileType.UNKNOWN || !Extractors.ContainsKey(type))
                     {
                         useRaw = true;
-                        result = new[]
+                        if (options.FileNamePasses(fileEntry.FullPath))
                         {
-                            fileEntry
-                        };
+                            result = new[]
+                            {
+                                fileEntry
+                            };
+                        }
                     }
                     else
                     {
@@ -662,9 +676,13 @@ namespace Microsoft.CST.RecursiveExtractor
                 Logger.Debug(ex, "Error extracting {0}: {1}", fileEntry.FullPath, ex.Message);
                 useRaw = true;
 
-                result = new[] {
-                    fileEntry
-                };
+                if (options.FileNamePasses(fileEntry.FullPath))
+                {
+                    result = new[]
+                    {
+                                fileEntry
+                    };
+                }
             }
 
             // After we are done with an archive subtract its bytes. Contents have been counted now separately

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -21,7 +21,6 @@ namespace Microsoft.CST.RecursiveExtractor
 {
     public class Extractor
     {
-     
         /// <summary>
         /// The main Extractor class.
         /// </summary>
@@ -109,7 +108,7 @@ namespace Microsoft.CST.RecursiveExtractor
                 {
                     if (stream1.CanRead && stream2.CanRead && stream1.Length == stream2.Length && fileEntry1.Name == fileEntry2.Name)
                     {
-                        var bufferSize = 1024;
+                        const int bufferSize = 1024;
                         var buffer1 = new byte[bufferSize];
                         var buffer2 = new byte[bufferSize];
 
@@ -162,7 +161,6 @@ namespace Microsoft.CST.RecursiveExtractor
 
             return false;
         }
-
 
         /// <summary>
         /// Deprecated. Use Extract.
@@ -299,7 +297,7 @@ namespace Microsoft.CST.RecursiveExtractor
         public IEnumerable<FileEntry> Extract(string filename, Stream stream, ExtractorOptions? opts = null)
         {
             opts ??= new ExtractorOptions();
-            FileEntry fileEntry = new FileEntry(filename, stream, memoryStreamCutoff: opts.MemoryStreamCutoff);
+            var fileEntry = new FileEntry(filename, stream, memoryStreamCutoff: opts.MemoryStreamCutoff);
             return Extract(fileEntry, opts);
         }
 
@@ -352,12 +350,12 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <returns>The FileEntrys found.</returns>
         public async IAsyncEnumerable<FileEntry> ExtractAsync(string filename, byte[] archiveBytes, ExtractorOptions? opts = null)
         {
-            opts = opts ?? new ExtractorOptions();
+            opts ??= new ExtractorOptions();
             using var ms = new MemoryStream(archiveBytes);
             await foreach (var entry in ExtractAsync(new FileEntry(Path.GetFileName(filename), ms, memoryStreamCutoff: opts.MemoryStreamCutoff), opts))
             {
                 yield return entry;
-            };
+            }
         }
 
         internal const string DEBUG_STRING = "Failed parsing archive of type {0} {1}:{2} ({3})";
@@ -395,14 +393,14 @@ namespace Microsoft.CST.RecursiveExtractor
         public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions? opts = null, ResourceGovernor? governor = null)
         {
             var options = opts ?? new ExtractorOptions();
-            
+
             var Governor = governor ?? new ResourceGovernor(options);
             if (governor is null)
             {
                 Governor.ResetResourceGovernor(fileEntry.Content);
             }
             Logger.Trace("ExtractFile({0})", fileEntry.FullPath);
-            
+
             Governor.CurrentOperationProcessedBytesLeft -= fileEntry.Content.Length;
             Governor.CheckResourceGovernor();
             var type = MiniMagic.DetectFileType(fileEntry);
@@ -431,7 +429,7 @@ namespace Microsoft.CST.RecursiveExtractor
             }
         }
 
-        private bool FileNamePasses(string fileName, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null)
+        private static bool FileNamePasses(string fileName, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null)
         {
             foreach (var allowRegex in acceptFilters ?? Array.Empty<Regex>())
             {
@@ -450,8 +448,6 @@ namespace Microsoft.CST.RecursiveExtractor
             return true;
         }
 
-
-
         /// <summary>
         /// Extract the given file to the given Directory.
         /// </summary>
@@ -460,7 +456,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="opts">The ExtractorOptions to use.</param>
         /// <param name="acceptFilters">An optional list of regexes, when set each entry's FullName must match at least one.</param>
         /// <param name="denyFilters">An optional list of regexes, when set each entry's FullName must match none.</param>
-        /// <param name="printNames">If we should print the filename when when writing it out to disc.</param>
+        /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public ExtractionStatusCode ExtractToDirectory(string outputDirectory, string filename, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
             using var fs = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
@@ -476,7 +472,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="opts">The ExtractorOptions to use.</param>
         /// <param name="acceptFilters">An optional list of regexes, when set each entry's FullName must match at least one.</param>
         /// <param name="denyFilters">An optional list of regexes, when set each entry's FullName must match none.</param>
-        /// <param name="printNames">If we should print the filename when when writing it out to disc.</param>
+        /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public ExtractionStatusCode ExtractToDirectory(string outputDirectory, string filename, Stream stream, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
             opts ??= new ExtractorOptions();
@@ -493,9 +489,9 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="opts">The ExtractorOptions to use.</param>
         /// <param name="acceptFilters">An optional list of regexes, when set each entry's FullName must match at least one.</param>
         /// <param name="denyFilters">An optional list of regexes, when set each entry's FullName must match none.</param>
-        /// <param name="printNames">If we should print the filename when when writing it out to disc.</param>
+        /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public ExtractionStatusCode ExtractToDirectory(string outputDirectory, FileEntry fileEntry, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
-        { 
+        {
             foreach (var entry in Extract(fileEntry, opts))
             {
                 if (FileNamePasses(entry.FullPath, acceptFilters, denyFilters))
@@ -538,11 +534,11 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="opts">The ExtractorOptions to use.</param>
         /// <param name="acceptFilters">An optional list of regexes, when set each entry's FullName must match at least one.</param>
         /// <param name="denyFilters">An optional list of regexes, when set each entry's FullName must match none.</param>
-        /// <param name="printNames">If we should print the filename when when writing it out to disc.</param>
+        /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public async Task<ExtractionStatusCode> ExtractToDirectoryAsync(string outputDirectory, string filename, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
             var fs = new FileStream(filename, FileMode.Open, FileAccess.Read, FileShare.Read);
-            return await ExtractToDirectoryAsync(outputDirectory, filename, fs, opts, acceptFilters, denyFilters, printNames);
+            return await ExtractToDirectoryAsync(outputDirectory, filename, fs, opts, acceptFilters, denyFilters, printNames).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -554,13 +550,13 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="opts">The ExtractorOptions to use.</param>
         /// <param name="acceptFilters">An optional list of regexes, when set each entry's FullName must match at least one.</param>
         /// <param name="denyFilters">An optional list of regexes, when set each entry's FullName must match none.</param>
-        /// <param name="printNames">If we should print the filename when when writing it out to disc.</param>
+        /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public async Task<ExtractionStatusCode> ExtractToDirectoryAsync(string outputDirectory, string filename, Stream stream, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
-            opts = opts ?? new ExtractorOptions();
+            opts ??= new ExtractorOptions();
             var file = Path.GetFileName(filename);
             var fileEntry = new FileEntry(Path.GetFileName(file), stream, memoryStreamCutoff: opts.MemoryStreamCutoff);
-            return await ExtractToDirectoryAsync(outputDirectory, fileEntry, opts, acceptFilters, denyFilters, printNames);
+            return await ExtractToDirectoryAsync(outputDirectory, fileEntry, opts, acceptFilters, denyFilters, printNames).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -571,7 +567,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="opts">The ExtractorOptions to use.</param>
         /// <param name="acceptFilters">An optional list of regexes, when set each entry's FullName must match at least one.</param>
         /// <param name="denyFilters">An optional list of regexes, when set each entry's FullName must match none.</param>
-        /// <param name="printNames">If we should print the filename when when writing it out to disc.</param>
+        /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public async Task<ExtractionStatusCode> ExtractToDirectoryAsync(string outputDirectory, FileEntry fileEntry, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
             await foreach (var entry in ExtractAsync(fileEntry, opts))
@@ -585,7 +581,7 @@ namespace Microsoft.CST.RecursiveExtractor
                         {
                             Directory.CreateDirectory(directoryPath);
                             using var fs = new FileStream(targetPathNotNull, FileMode.Create);
-                            await entry.Content.CopyToAsync(fs);
+                            await entry.Content.CopyToAsync(fs).ConfigureAwait(false);
                             if (printNames)
                             {
                                 Console.WriteLine("Extracted {0}.", entry.FullPath);

--- a/RecursiveExtractor/ExtractorOptions.cs
+++ b/RecursiveExtractor/ExtractorOptions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.CST.RecursiveExtractor
 
         public bool FileNamePasses(string filename)
         {
-            bool allowed = true;
+            var allowed = true;
             if (_allowGlobs.Any())
             {
                 allowed = false;

--- a/RecursiveExtractor/Extractors/BZip2Extractor.cs
+++ b/RecursiveExtractor/Extractors/BZip2Extractor.cs
@@ -58,6 +58,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             }
         }
 
+        /// <summary>
         ///     Extracts a BZip2 file contained in fileEntry.
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>

--- a/RecursiveExtractor/Extractors/BZip2Extractor.cs
+++ b/RecursiveExtractor/Extractors/BZip2Extractor.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             }
             var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
 
-            var entry = await FileEntry.FromStreamAsync(newFilename, fs, fileEntry);
+            var entry = await FileEntry.FromStreamAsync(newFilename, fs, fileEntry).ConfigureAwait(false);
 
             if (entry != null)
             {

--- a/RecursiveExtractor/Extractors/DebExtractor.cs
+++ b/RecursiveExtractor/Extractors/DebExtractor.cs
@@ -71,7 +71,11 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
                         selectedEntries.AsParallel().ForAll(entry =>
                         {
-                            files.PushRange(Context.Extract(entry, options, governor).ToArray());
+                            var newEntries = Context.Extract(entry, options, governor).ToArray();
+                            if (newEntries.Any())
+                            {
+                                files.PushRange(newEntries);
+                            }
                         });
 
                         entries = entries.Skip(batchSize);

--- a/RecursiveExtractor/Extractors/DebExtractor.cs
+++ b/RecursiveExtractor/Extractors/DebExtractor.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         selectedEntries.AsParallel().ForAll(entry =>
                         {
                             var newEntries = Context.Extract(entry, options, governor).ToArray();
-                            if (newEntries.Length)
+                            if (newEntries.Length > 0)
                             {
                                 files.PushRange(newEntries);
                             }

--- a/RecursiveExtractor/Extractors/DebExtractor.cs
+++ b/RecursiveExtractor/Extractors/DebExtractor.cs
@@ -72,7 +72,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         selectedEntries.AsParallel().ForAll(entry =>
                         {
                             var newEntries = Context.Extract(entry, options, governor).ToArray();
-                            if (newEntries.Any())
+                            if (newEntries.Length)
                             {
                                 files.PushRange(newEntries);
                             }

--- a/RecursiveExtractor/Extractors/DiscCommon.cs
+++ b/RecursiveExtractor/Extractors/DiscCommon.cs
@@ -147,6 +147,10 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         try
                         {
                             var fi = fs.GetFileInfo(file);
+                            if (!options.FileNamePasses(fi.FullName))
+                            {
+                                continue;
+                            }
                             governor.CheckResourceGovernor(fi.Length);
                             fileStream = fi.OpenRead();
                             creation = fi.CreationTime;
@@ -160,8 +164,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         if (fileStream != null)
                         {
                             var newFileEntry = new FileEntry($"{volume.Identity}{Path.DirectorySeparatorChar}{file}", fileStream, parent, false, creation, modification, access, memoryStreamCutoff: options.MemoryStreamCutoff);
-                            var entries = Context.Extract(newFileEntry, options, governor);
-                            foreach (var entry in entries)
+                            foreach (var entry in Context.Extract(newFileEntry, options, governor))
                             {
                                 yield return entry;
                             }

--- a/RecursiveExtractor/Extractors/DiscCommon.cs
+++ b/RecursiveExtractor/Extractors/DiscCommon.cs
@@ -57,9 +57,8 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     }
                     if (fileStream != null && fi != null)
                     {
-                        var newFileEntry = await FileEntry.FromStreamAsync($"{volume.Identity}{Path.DirectorySeparatorChar}{fi.FullName}", fileStream, parent, fi.CreationTime, fi.LastWriteTime, fi.LastAccessTime, memoryStreamCutoff: options.MemoryStreamCutoff);
-                        var entries = Context.ExtractAsync(newFileEntry, options, governor);
-                        await foreach (var entry in entries)
+                        var newFileEntry = await FileEntry.FromStreamAsync($"{volume.Identity}{Path.DirectorySeparatorChar}{fi.FullName}", fileStream, parent, fi.CreationTime, fi.LastWriteTime, fi.LastAccessTime, memoryStreamCutoff: options.MemoryStreamCutoff).ConfigureAwait(false);
+                        await foreach (var entry in Context.ExtractAsync(newFileEntry, options, governor))
                         {
                             yield return entry;
                         }
@@ -98,7 +97,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 {
                     var files = new ConcurrentStack<FileEntry>();
 
-                    while (diskFiles.Any())
+                    while (diskFiles.Count > 0)
                     {
                         var batchSize = Math.Min(options.BatchSize, diskFiles.Count);
                         var range = diskFiles.GetRange(0, batchSize);

--- a/RecursiveExtractor/Extractors/DiscCommon.cs
+++ b/RecursiveExtractor/Extractors/DiscCommon.cs
@@ -120,13 +120,18 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
                         governor.CheckResourceGovernor(totalLength);
 
+                        var validFileInfos = fileinfos.Where(x => options.FileNamePasses($"{parent?.FullPath}{Path.DirectorySeparatorChar}{x.name}"));
+
                         fileinfos.AsParallel().ForAll(file =>
                         {
                             if (file.stream != null)
                             {
                                 var newFileEntry = new FileEntry($"{volume.Identity}{Path.DirectorySeparatorChar}{file.name}", file.stream, parent, false, file.created, file.modified, file.accessed, memoryStreamCutoff: options.MemoryStreamCutoff);
-                                var entries = Context.Extract(newFileEntry, options, governor);
-                                files.PushRange(entries.ToArray());
+                                var entries = Context.Extract(newFileEntry, options, governor).ToArray();
+                                if (entries.Length > 0)
+                                {
+                                    files.PushRange(entries);
+                                }
                             }
                         });
                         diskFiles.RemoveRange(0, batchSize);

--- a/RecursiveExtractor/Extractors/GnuArExtractor.cs
+++ b/RecursiveExtractor/Extractors/GnuArExtractor.cs
@@ -42,7 +42,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         ///     Extracts an archive file created with GNU ar
         /// </summary>
         /// <param name="fileEntry"> </param>
-        /// <returns> </returns>      
+        /// <returns> </returns>
         public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
         {
             IEnumerable<FileEntry>? fileEntries = null;

--- a/RecursiveExtractor/Extractors/GnuArExtractor.cs
+++ b/RecursiveExtractor/Extractors/GnuArExtractor.cs
@@ -27,7 +27,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        ///         
         public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
         {
             await foreach (var entry in ArFile.GetFileEntriesAsync(fileEntry, options, governor))
@@ -43,8 +42,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         ///     Extracts an archive file created with GNU ar
         /// </summary>
         /// <param name="fileEntry"> </param>
-        /// <returns> </returns>
-        ///         
+        /// <returns> </returns>      
         public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
         {
             IEnumerable<FileEntry>? fileEntries = null;
@@ -68,10 +66,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     {
                         var tempStore = new ConcurrentStack<FileEntry>();
                         var selectedEntries = fileEntries.Take(options.BatchSize);
-                        selectedEntries.AsParallel().ForAll(arEntry =>
-                        {
-                            tempStore.PushRange(Context.Extract(arEntry, options, governor).ToArray());
-                        });
+                        selectedEntries.AsParallel().ForAll(arEntry => tempStore.PushRange(Context.Extract(arEntry, options, governor).ToArray()));
 
                         fileEntries = fileEntries.Skip(selectedEntries.Count());
 
@@ -101,6 +96,5 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 }
             }
         }
-
     }
 }

--- a/RecursiveExtractor/Extractors/GzipExtractor.cs
+++ b/RecursiveExtractor/Extractors/GzipExtractor.cs
@@ -73,16 +73,17 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
         {
             using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
-            
+
             try
             {
                 GZip.Decompress(fileEntry.Content, fs, false);
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 Logger.Debug(Extractor.DEBUG_STRING, "GZip", e.GetType(), e.Message, e.StackTrace);
                 yield break;
             }
+
             var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
             if (fileEntry.Name.EndsWith(".tgz", StringComparison.InvariantCultureIgnoreCase))
             {
@@ -91,7 +92,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
             var entry = new FileEntry(newFilename, fs, fileEntry);
 
-            if (entry != null)
+            if (entry != null && options.FileNamePasses(entry.FullPath))
             {
                 if (Extractor.IsQuine(entry))
                 {

--- a/RecursiveExtractor/Extractors/GzipExtractor.cs
+++ b/RecursiveExtractor/Extractors/GzipExtractor.cs
@@ -47,7 +47,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 newFilename = newFilename[0..^4] + ".tar";
             }
 
-            var entry = await FileEntry.FromStreamAsync(newFilename, fs, fileEntry);
+            var entry = await FileEntry.FromStreamAsync(newFilename, fs, fileEntry).ConfigureAwait(false);
 
             if (entry != null)
             {

--- a/RecursiveExtractor/Extractors/IsoExtractor.cs
+++ b/RecursiveExtractor/Extractors/IsoExtractor.cs
@@ -26,7 +26,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         internal Extractor Context { get; }
 
         /// <summary>
-        ///     Extracts an an ISO file
+        ///     Extracts an ISO file
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
@@ -52,7 +52,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     if (stream != null)
                     {
                         var name = fileInfo.FullName.Replace('/', Path.DirectorySeparatorChar);
-                        var newFileEntry = await FileEntry.FromStreamAsync(name, stream, fileEntry, fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.LastAccessTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                        var newFileEntry = await FileEntry.FromStreamAsync(name, stream, fileEntry, fileInfo.CreationTime, fileInfo.LastWriteTime, fileInfo.LastAccessTime, memoryStreamCutoff: options.MemoryStreamCutoff).ConfigureAwait(false);
                         var innerEntries = Context.ExtractAsync(newFileEntry, options, governor);
                         await foreach (var entry in innerEntries)
                         {
@@ -71,7 +71,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         }
 
         /// <summary>
-        ///     Extracts an an ISO file
+        ///     Extracts an ISO file
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>

--- a/RecursiveExtractor/Extractors/RarExtractor.cs
+++ b/RecursiveExtractor/Extractors/RarExtractor.cs
@@ -88,23 +88,24 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             var rarArchive = GetRarArchive(fileEntry, options);
             if (rarArchive != null)
             {
-                var entries = rarArchive.Entries.Where(x => x.IsComplete && !x.IsDirectory);
-
-                foreach (var entry in entries)
+                foreach (var entry in rarArchive.Entries.Where(x => x.IsComplete && !x.IsDirectory))
                 {
                     governor.CheckResourceGovernor(entry.Size);
                     var name = entry.Key.Replace('/', Path.DirectorySeparatorChar);
-                    FileEntry newFileEntry = await FileEntry.FromStreamAsync(name, entry.OpenEntryStream(), fileEntry, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff);
-                    if (newFileEntry != null)
+                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        if (Extractor.IsQuine(newFileEntry))
+                        FileEntry newFileEntry = await FileEntry.FromStreamAsync(name, entry.OpenEntryStream(), fileEntry, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                        if (newFileEntry != null)
                         {
-                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                            throw new OverflowException();
-                        }
-                        await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
-                        {
-                            yield return extractedFile;
+                            if (Extractor.IsQuine(newFileEntry))
+                            {
+                                Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                                throw new OverflowException();
+                            }
+                            await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
+                            {
+                                yield return extractedFile;
+                            }
                         }
                     }
                 }
@@ -181,8 +182,10 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         try
                         {
                             var name = entry.Key.Replace('/', Path.DirectorySeparatorChar);
-
-                            newFileEntry = new FileEntry(name, entry.OpenEntryStream(), fileEntry, false, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                            if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
+                            {
+                                newFileEntry = new FileEntry(name, entry.OpenEntryStream(), fileEntry, false, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                            }
                         }
                         catch (Exception e)
                         {

--- a/RecursiveExtractor/Extractors/RarExtractor.cs
+++ b/RecursiveExtractor/Extractors/RarExtractor.cs
@@ -64,8 +64,9 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                             foreach(var entry in rarArchive.Entries)
                             {
                                 //Just do anything in the loop, but you need to loop over entries to check if the password is correct
-                                count++; 
+                                count++;
                             }
+                            passwordFound = true;
                             break;
                         }
                         catch (Exception e)
@@ -94,7 +95,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     var name = entry.Key.Replace('/', Path.DirectorySeparatorChar);
                     if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        FileEntry newFileEntry = await FileEntry.FromStreamAsync(name, entry.OpenEntryStream(), fileEntry, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                        var newFileEntry = await FileEntry.FromStreamAsync(name, entry.OpenEntryStream(), fileEntry, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff).ConfigureAwait(false);
                         if (newFileEntry != null)
                         {
                             if (Extractor.IsQuine(newFileEntry))

--- a/RecursiveExtractor/Extractors/SevenZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/SevenZipExtractor.cs
@@ -30,7 +30,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>
         /// <returns> Extracted files </returns>
-
         public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
         {
             var sevenZipArchive = GetSevenZipArchive(fileEntry, options);
@@ -44,7 +43,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     var name = entry.Key.Replace('/', Path.DirectorySeparatorChar);
                     if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        var newFileEntry = await FileEntry.FromStreamAsync(name, entry.OpenEntryStream(), fileEntry, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                        var newFileEntry = await FileEntry.FromStreamAsync(name, entry.OpenEntryStream(), fileEntry, entry.CreatedTime, entry.LastModifiedTime, entry.LastAccessedTime, memoryStreamCutoff: options.MemoryStreamCutoff).ConfigureAwait(false);
 
                         if (Extractor.IsQuine(newFileEntry))
                         {
@@ -119,7 +118,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>
         /// <returns> Extracted files </returns>
-
         public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
         {
             var sevenZipArchive = GetSevenZipArchive(fileEntry, options);
@@ -132,7 +130,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
                     while (entries.Count > 0)
                     {
-                        var batchSize = Math.Min(options.BatchSize, entries.Count());
+                        var batchSize = Math.Min(options.BatchSize, entries.Count);
                         var selectedEntries = entries.GetRange(0, batchSize).Select(entry => (entry, entry.OpenEntryStream()));
                         governor.CheckResourceGovernor(selectedEntries.Sum(x => x.entry.Size));
 
@@ -218,6 +216,5 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 }
             }
         }
-
     }
 }

--- a/RecursiveExtractor/Extractors/TarExtractor.cs
+++ b/RecursiveExtractor/Extractors/TarExtractor.cs
@@ -60,18 +60,20 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     }
 
                     var name = tarEntry.Name.Replace('/', Path.DirectorySeparatorChar);
-
-                    var newFileEntry = new FileEntry(name, fs, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
-
-                    if (Extractor.IsQuine(newFileEntry))
+                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                        throw new OverflowException();
-                    }
+                        var newFileEntry = new FileEntry(name, fs, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                    await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
-                    {
-                        yield return extractedFile;
+                        if (Extractor.IsQuine(newFileEntry))
+                        {
+                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                            throw new OverflowException();
+                        }
+
+                        await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
+                        {
+                            yield return extractedFile;
+                        }
                     }
                 }
                 tarStream.Dispose();
@@ -122,18 +124,20 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         Logger.Debug(Extractor.DEBUG_STRING, ArchiveFileType.TAR, fileEntry.FullPath, tarEntry.Name, e.GetType());
                     }
                     var name = tarEntry.Name.Replace('/', Path.DirectorySeparatorChar);
-
-                    var newFileEntry = new FileEntry(name, fs, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
-
-                    if (Extractor.IsQuine(newFileEntry))
+                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                        throw new OverflowException();
-                    }
+                        var newFileEntry = new FileEntry(name, fs, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                    foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
-                    {
-                        yield return extractedFile;
+                        if (Extractor.IsQuine(newFileEntry))
+                        {
+                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                            throw new OverflowException();
+                        }
+
+                        foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
+                        {
+                            yield return extractedFile;
+                        }
                     }
                 }
                 tarStream.Dispose();

--- a/RecursiveExtractor/Extractors/WimExtractor.cs
+++ b/RecursiveExtractor/Extractors/WimExtractor.cs
@@ -109,7 +109,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                             if (stream != null)
                             {
                                 var name = file.Replace('\\', Path.DirectorySeparatorChar);
-                                var newFileEntry = await FileEntry.FromStreamAsync($"{image.FriendlyName}{Path.DirectorySeparatorChar}{name}", stream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
+                                var newFileEntry = await FileEntry.FromStreamAsync($"{image.FriendlyName}{Path.DirectorySeparatorChar}{name}", stream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff).ConfigureAwait(false);
                                 await foreach (var entry in Context.ExtractAsync(newFileEntry, options, governor))
                                 {
                                     yield return entry;
@@ -185,6 +185,5 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 }
             }
         }
-
     }
 }

--- a/RecursiveExtractor/Extractors/XzExtractor.cs
+++ b/RecursiveExtractor/Extractors/XzExtractor.cs
@@ -42,30 +42,33 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             if (xzStream != null)
             {
                 var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
-                var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
-
-                // SharpCompress does not expose metadata without a full read, so we need to decompress first,
-                // and then abort if the bytes exceeded the governor's capacity.
-
-                var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
-                                          .Aggregate((ulong?)0, (a, b) => a + b);
-
-                // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
-                // low risk.
-                if (streamLength.HasValue)
+                if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{newFilename}"))
                 {
-                    governor.CheckResourceGovernor((long)streamLength.Value);
-                }
+                    var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                if (Extractor.IsQuine(newFileEntry))
-                {
-                    Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                    throw new OverflowException();
-                }
+                    // SharpCompress does not expose metadata without a full read, so we need to decompress first,
+                    // and then abort if the bytes exceeded the governor's capacity.
 
-                await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
-                {
-                    yield return extractedFile;
+                    var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
+                                              .Aggregate((ulong?)0, (a, b) => a + b);
+
+                    // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
+                    // low risk.
+                    if (streamLength.HasValue)
+                    {
+                        governor.CheckResourceGovernor((long)streamLength.Value);
+                    }
+
+                    if (Extractor.IsQuine(newFileEntry))
+                    {
+                        Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                        throw new OverflowException();
+                    }
+
+                    await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
+                    {
+                        yield return extractedFile;
+                    }
                 }
                 xzStream.Dispose();
             }
@@ -97,30 +100,33 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             if (xzStream != null)
             {
                 var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
-                var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
-
-                // SharpCompress does not expose metadata without a full read, so we need to decompress first,
-                // and then abort if the bytes exceeded the governor's capacity.
-
-                var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
-                                          .Aggregate((ulong?)0, (a, b) => a + b);
-
-                // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
-                // low risk.
-                if (streamLength.HasValue)
+                if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{newFilename}"))
                 {
-                    governor.CheckResourceGovernor((long)streamLength.Value);
-                }
+                    var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                if (Extractor.IsQuine(newFileEntry))
-                {
-                    Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                    throw new OverflowException();
-                }
+                    // SharpCompress does not expose metadata without a full read, so we need to decompress first,
+                    // and then abort if the bytes exceeded the governor's capacity.
 
-                foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
-                {
-                    yield return extractedFile;
+                    var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
+                                              .Aggregate((ulong?)0, (a, b) => a + b);
+
+                    // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
+                    // low risk.
+                    if (streamLength.HasValue)
+                    {
+                        governor.CheckResourceGovernor((long)streamLength.Value);
+                    }
+
+                    if (Extractor.IsQuine(newFileEntry))
+                    {
+                        Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                        throw new OverflowException();
+                    }
+
+                    foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
+                    {
+                        yield return extractedFile;
+                    }
                 }
                 xzStream.Dispose();
             }

--- a/RecursiveExtractor/Extractors/XzExtractor.cs
+++ b/RecursiveExtractor/Extractors/XzExtractor.cs
@@ -138,6 +138,5 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 }
             }
         }
-
     }
 }

--- a/RecursiveExtractor/Extractors/ZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/ZipExtractor.cs
@@ -160,7 +160,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     {
                         Logger.Debug(Extractor.DEBUG_STRING, ArchiveFileType.ZIP, fileEntry.FullPath, zipEntry.Name, e.GetType());
                     }
-            
+
                     var name = zipEntry.Name.Replace('/', Path.DirectorySeparatorChar);
                     if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {

--- a/RecursiveExtractor/Extractors/ZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/ZipExtractor.cs
@@ -95,17 +95,20 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     }
 
                     var name = zipEntry.Name.Replace('/', Path.DirectorySeparatorChar);
-                    var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
-
-                    if (Extractor.IsQuine(newFileEntry))
+                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                        throw new OverflowException();
-                    }
+                        var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                    await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
-                    {
-                        yield return extractedFile;
+                        if (Extractor.IsQuine(newFileEntry))
+                        {
+                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                            throw new OverflowException();
+                        }
+
+                        await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
+                        {
+                            yield return extractedFile;
+                        }
                     }
                 }
             }
@@ -161,18 +164,20 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     }
                     
                     var name = zipEntry.Name.Replace('/', Path.DirectorySeparatorChar);
-
-                    var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
-
-                    if (Extractor.IsQuine(newFileEntry))
+                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
-                        Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                        throw new OverflowException();
-                    }
+                        var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                    foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
-                    {
-                        yield return extractedFile;
+                        if (Extractor.IsQuine(newFileEntry))
+                        {
+                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
+                            throw new OverflowException();
+                        }
+
+                        foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
+                        {
+                            yield return extractedFile;
+                        }
                     }
                 }
             }

--- a/RecursiveExtractor/Extractors/ZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/ZipExtractor.cs
@@ -68,8 +68,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 var passwordFound = false;
                 foreach (ZipEntry? zipEntry in zipFile)
                 {
-                    if (zipEntry is null ||
-                        zipEntry.IsDirectory ||
+                    if (zipEntry?.IsDirectory != false ||
                         !zipEntry.CanDecompress)
                     {
                         continue;
@@ -136,8 +135,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 var passwordFound = false;
                 foreach (ZipEntry? zipEntry in zipFile)
                 {
-                    if (zipEntry is null ||
-                        zipEntry.IsDirectory ||
+                    if (zipEntry?.IsDirectory != false ||
                         !zipEntry.CanDecompress)
                     {
                         continue;
@@ -162,7 +160,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     {
                         Logger.Debug(Extractor.DEBUG_STRING, ArchiveFileType.ZIP, fileEntry.FullPath, zipEntry.Name, e.GetType());
                     }
-                    
+            
                     var name = zipEntry.Name.Replace('/', Path.DirectorySeparatorChar);
                     if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
                     {
@@ -182,8 +180,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 }
             }
         }
-        
-        private const int bufferSize = 4096;
 
+        private const int bufferSize = 4096;
     }
 }

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -24,7 +24,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="passthroughStream"> </param>
         public FileEntry(string name, Stream inputStream, FileEntry? parent = null, bool passthroughStream = false, DateTime? createTime = null, DateTime? modifyTime = null, DateTime? accessTime = null, int? memoryStreamCutoff = null)
         {
-            memoryStreamCutoff = memoryStreamCutoff ?? defaultCutoff;
+            memoryStreamCutoff ??= defaultCutoff;
 
             Parent = parent;
             Passthrough = passthroughStream;
@@ -196,7 +196,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <returns>A FileEntry object holding a Copy of the Stream</returns>
         public static async Task<FileEntry> FromStreamAsync(string name, Stream content, FileEntry? parent = null, DateTime? createTime = null, DateTime? modifyTime = null, DateTime? accessTime = null, int? memoryStreamCutoff = null)
         {
-            memoryStreamCutoff = memoryStreamCutoff ?? defaultCutoff;
+            memoryStreamCutoff ??= defaultCutoff;
             if (!content.CanRead || content == null)
             {
                 content = new MemoryStream();
@@ -213,7 +213,7 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 FullPath = $"{parent?.FullPath}{Path.DirectorySeparatorChar}{name}";
             }
-            Stream Content = new MemoryStream();
+            Stream Content;
 
             try
             {
@@ -244,7 +244,7 @@ namespace Microsoft.CST.RecursiveExtractor
 
             try
             {
-                await content.CopyToAsync(Content);
+                await content.CopyToAsync(Content).ConfigureAwait(false);
             }
             catch (NotSupportedException)
             {

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -274,6 +274,6 @@ namespace Microsoft.CST.RecursiveExtractor
             return new FileEntry(name, Content, parent, true, createTime, modifyTime, accessTime);
         }
 
-        private static int defaultCutoff = 1024 * 1024 * 100;
+        private const int defaultCutoff = 1024 * 1024 * 100;
     }
 }

--- a/RecursiveExtractor/RecursiveExtractor.csproj
+++ b/RecursiveExtractor/RecursiveExtractor.csproj
@@ -37,6 +37,7 @@
     <PackageReference Include="DiscUtils.Vmdk" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.Wim" Version="0.15.1-ci0002" />
     <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
+    <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
     <PackageReference Include="NLog" Version="4.7.9" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />


### PR DESCRIPTION
Previously only the ExtractToDirectory took filtering and it was Regexes.

Now the actual extract command takes glob arguments for ignore and restrict allow.

Added tests for same.