### PR TITLE
Add an opt-out of recursion

### DIFF
--- a/RecursiveExtractor.Blazor/RecursiveExtractor.Blazor.csproj
+++ b/RecursiveExtractor.Blazor/RecursiveExtractor.Blazor.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="5.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="5.0.6" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.221" />
+    <PackageReference Include="Microsoft.CST.DevSkim" Version="0.4.234" />
     <PackageReference Include="System.Net.Http.Json" Version="5.0.0" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.0.0.20340" />
   </ItemGroup>
@@ -29,7 +29,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.205" />
   </ItemGroup>
 
 </Project>

--- a/RecursiveExtractor.Cli/ExtractCommandOptions.cs
+++ b/RecursiveExtractor.Cli/ExtractCommandOptions.cs
@@ -27,6 +27,9 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
         [Option('n', "no-recursion", Required = false, HelpText = "Disable recursive extraction.")]
         public bool DisableRecursion { get; set; }
 
+        [Option('s', "single-thread", Required = false, HelpText = "Disable parallelized extraction.")]
+        public bool SingleThread { get; set; }
+
         [Option(HelpText = "Set logging to 'verbose'.")]
 		public bool Verbose { get; set; }
 

--- a/RecursiveExtractor.Cli/ExtractCommandOptions.cs
+++ b/RecursiveExtractor.Cli/ExtractCommandOptions.cs
@@ -15,10 +15,10 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
         [Option('p', "passwords", Required = false, HelpText = "Comma-separated list of passwords to use.", Separator = ',')]
         public IEnumerable<string>? Passwords { get; set; }
 
-        [Option('A', "allow-filters", Required = false, HelpText = "Comma-separated list of regular expressions. When set, files are ONLY written to disk if they match one of these filters.", Separator = ',')]
+        [Option('a', "allow-globs", Required = false, HelpText = "Comma-separated list of glob expressions. When set, files are ONLY written to disk if they match one of these filters.", Separator = ',')]
         public IEnumerable<string>? AllowFilters { get; set; }
 
-        [Option('D', "deny-filters", Required = false, HelpText = "Comma-separated list of regular expressions. When set, files are NOT written to disk if they match one of these filters.", Separator = ',')]
+        [Option('d', "deny-globs", Required = false, HelpText = "Comma-separated list of glob expressions. When set, files are NOT written to disk if they match one of these filters.", Separator = ',')]
         public IEnumerable<string>? DenyFilters { get; set; }
 
         [Option('R', "raw-extensions", Required = false, HelpText = "Comma-separated list of file extensions to treat as raw files (don't recurse into).", Separator = ',')]

--- a/RecursiveExtractor.Cli/ExtractCommandOptions.cs
+++ b/RecursiveExtractor.Cli/ExtractCommandOptions.cs
@@ -24,6 +24,9 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
         [Option('R', "raw-extensions", Required = false, HelpText = "Comma-separated list of file extensions to treat as raw files (don't recurse into).", Separator = ',')]
         public IEnumerable<string>? RawExtensions { get; set; }
 
+        [Option('n', "no-recursion", Required = false, HelpText = "Disable recursive extraction.")]
+        public bool DisableRecursion { get; set; }
+
         [Option(HelpText = "Set logging to 'verbose'.")]
 		public bool Verbose { get; set; }
 

--- a/RecursiveExtractor.Cli/RecursiveExtractor.Cli.csproj
+++ b/RecursiveExtractor.Cli/RecursiveExtractor.Cli.csproj
@@ -38,6 +38,6 @@
   </ItemGroup>
  
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.205" />
   </ItemGroup>  
 </Project>

--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -62,10 +62,18 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
                     }
                 };
             }
+            var exitCode = ExtractionStatusCode.Ok;
+            try
+            {
+                exitCode = extractor.ExtractToDirectory(options.Output, options.Input, extractorOptions, options.PrintNames);
+            }
+            catch(Exception e)
+            {
+                Logger.Error($"Exception while extracting. {e.GetType()}:{e.Message} ({e.StackTrace})");
+                exitCode = ExtractionStatusCode.Failure;
+            }
 
-            extractor.ExtractToDirectory(options.Output, options.Input, extractorOptions, options.PrintNames);
-
-            return 0;
+            return (int)exitCode;
         }
         private readonly static NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
     }

--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -60,6 +60,14 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
                     }
                 };
             }
+            if (options.AllowFilters != null)
+            {
+                extractorOptions.AllowFilters = options.AllowFilters;
+            }
+            if (options.DenyFilters != null)
+            {
+                extractorOptions.DenyFilters = options.DenyFilters;
+            }
             var allowRegexes = options.AllowFilters?.Select(x => new Regex(x)) ?? Array.Empty<Regex>();
             var denyRegexes = options.DenyFilters?.Select(x => new Regex(x)) ?? Array.Empty<Regex>();
             extractor.ExtractToDirectory(options.Output, options.Input, extractorOptions, allowRegexes, denyRegexes, options.PrintNames);

--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -46,9 +46,11 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
             var extractorOptions = new ExtractorOptions()
             {
                 ExtractSelfOnFail = true,
-                Parallel = true,
+                Parallel = !options.SingleThread,
                 RawExtensions = options.RawExtensions ?? Array.Empty<string>(),
-                Recurse = !options.DisableRecursion
+                Recurse = !options.DisableRecursion,
+                AllowFilters = options.AllowFilters ?? Array.Empty<string>(),
+                DenyFilters = options.DenyFilters ?? Array.Empty<string>()
             };
             if (options.Passwords?.Any() ?? false)
             {
@@ -60,17 +62,8 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
                     }
                 };
             }
-            if (options.AllowFilters != null)
-            {
-                extractorOptions.AllowFilters = options.AllowFilters;
-            }
-            if (options.DenyFilters != null)
-            {
-                extractorOptions.DenyFilters = options.DenyFilters;
-            }
-            var allowRegexes = options.AllowFilters?.Select(x => new Regex(x)) ?? Array.Empty<Regex>();
-            var denyRegexes = options.DenyFilters?.Select(x => new Regex(x)) ?? Array.Empty<Regex>();
-            extractor.ExtractToDirectory(options.Output, options.Input, extractorOptions, allowRegexes, denyRegexes, options.PrintNames);
+
+            extractor.ExtractToDirectory(options.Output, options.Input, extractorOptions, options.PrintNames);
 
             return 0;
         }

--- a/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
+++ b/RecursiveExtractor.Cli/RecursiveExtractorClient.cs
@@ -47,7 +47,8 @@ namespace Microsoft.CST.RecursiveExtractor.Cli
             {
                 ExtractSelfOnFail = true,
                 Parallel = true,
-                RawExtensions = options.RawExtensions ?? Array.Empty<string>()
+                RawExtensions = options.RawExtensions ?? Array.Empty<string>(),
+                Recurse = !options.DisableRecursion
             };
             if (options.Passwords?.Any() ?? false)
             {

--- a/RecursiveExtractor.Tests/CliTests.cs
+++ b/RecursiveExtractor.Tests/CliTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
                 Verbose = true,
                 AllowFilters = new string[]
                 {
-                    ".[cC][sS]$"
+                    "*.cs"
                 }
             });
             var files = Array.Empty<string>();
@@ -87,7 +87,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
                 Verbose = true,
                 DenyFilters = new string[]
                 {
-                    ".[cC][sS]$"
+                    "*.cs"
                 }
             });
             var files = Array.Empty<string>();

--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -86,6 +86,85 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         [DataRow("TestData.tar", 5)]
         [DataRow("TestData.rar")]
         [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 1)]
+        [DataRow("TestData.tar.gz", 1)]
+        [DataRow("TestData.tar.xz", 1)]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 2)]
+        [DataRow("TestData.a")]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 14)]
+        public async Task ExtractArchiveAsyncNoRecursion(string fileName, int expectedNumFiles = 3)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var numResults = 0;
+            await foreach(var result in extractor.ExtractAsync(path, new ExtractorOptions() { Recurse = false }))
+            {
+                numResults++;
+            }
+            Assert.AreEqual(expectedNumFiles, numResults);
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip", 5)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 5)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 1)]
+        [DataRow("TestData.tar.gz", 1)]
+        [DataRow("TestData.tar.xz", 1)]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 2)]
+        [DataRow("TestData.a")]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 14)]
+        public void ExtractArchiveParallelNoRecursion(string fileName, int expectedNumFiles = 3)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { Parallel = true, Recurse = false });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip", 5)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 5)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 1)]
+        [DataRow("TestData.tar.gz", 1)]
+        [DataRow("TestData.tar.xz", 1)]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 2)]
+        [DataRow("TestData.a")]
+        //[DataRow("TestData.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 14)]
+        public void ExtractArchiveNoRecursion(string fileName, int expectedNumFiles = 3)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { Recurse = false });
+            Assert.AreEqual(expectedNumFiles, results.Count());
+        }
+
+        [DataTestMethod]
+        [DataRow("TestData.zip", 5)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 5)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
         [DataRow("TestData.tar.bz2", 5)]
         [DataRow("TestData.tar.gz", 5)]
         [DataRow("TestData.tar.xz")]
@@ -146,7 +225,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         [DataRow("TestData.vhdx")]
         [DataRow("TestData.wim")]
         [DataRow("EmptyFile.txt", 0)]
-        [DataRow("TestDataArchivesNested.Zip", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 9)]
         public async Task ExtractArchiveAsyncAllowFiltered(string fileName, int expectedNumFiles = 1)
         {
             var extractor = new Extractor();
@@ -176,7 +255,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         [DataRow("TestData.vhdx")]
         [DataRow("TestData.wim")]
         [DataRow("EmptyFile.txt", 0)]
-        [DataRow("TestDataArchivesNested.Zip", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 9)]
         public void ExtractArchiveAllowFiltered(string fileName, int expectedNumFiles = 1)
         {
             var extractor = new Extractor();
@@ -201,7 +280,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         [DataRow("TestData.vhdx")]
         [DataRow("TestData.wim")]
         [DataRow("EmptyFile.txt", 0)]
-        [DataRow("TestDataArchivesNested.Zip", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 9)]
         public void ExtractArchiveParallelAllowFiltered(string fileName, int expectedNumFiles = 1)
         {
             var extractor = new Extractor();
@@ -515,28 +594,12 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         [DataRow("zblg.zip")]
         [DataRow("zbsm.zip")]
         [DataRow("zbxl.zip")]
+        [ExpectedException(typeof(OverflowException))]
         public void TestQuineBombs(string fileName)
         {
             var extractor = new Extractor();
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "Bombs", fileName);
-            IEnumerable<FileEntry> results;
-            try
-            {
-                results = extractor.Extract(path, new ExtractorOptions() { MemoryStreamCutoff = 1024*1024*1024 }).ToList();
-                // Getting here means we didnt catch the bomb
-            }
-            // We should throw an overflow exception when we detect a quine or bomb
-            catch (Exception e) when (
-                    e is OverflowException)
-            {
-                return;
-            }
-            catch (Exception e)
-            {
-                Logger.Debug(e, "Shouldn't hit other exceptions in this test.");
-            }
-            // Getting here means we didnt catch the bomb
-            Assert.Fail();
+            _ = extractor.Extract(path, new ExtractorOptions() { MemoryStreamCutoff = 1024 * 1024 * 1024 }).ToList();
         }
 
         [DataTestMethod]

--- a/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
+++ b/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
@@ -11,15 +11,15 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.0" />
-    <PackageReference Include="DiscUtils.Btrfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.HfsPlus" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.SquashFs" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />
+    <PackageReference Include="DiscUtils.Btrfs" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.HfsPlus" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.SquashFs" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Xfs" Version="0.16.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.7.2" />
-    <PackageReference Include="Sarif.Sdk" Version="2.4.8" />
+    <PackageReference Include="Sarif.Sdk" Version="2.4.9" />
   </ItemGroup>
 
   <ItemGroup>
@@ -266,6 +266,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.194" />
+    <PackageReference Update="Nerdbank.GitVersioning" Version="3.4.205" />
   </ItemGroup>
 </Project>

--- a/RecursiveExtractor/ArFile.cs
+++ b/RecursiveExtractor/ArFile.cs
@@ -83,11 +83,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             // The name length is included in the total size reported in the header
                             CopyStreamBytes(fileEntry.Content, entryStream, size - nameLength);
 
-                            var entry = new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
-                            if (options.FileNamePasses(entry.FullPath))
-                            {
-                                yield return entry;
-                            }
+                            yield return new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true, memoryStreamCutoff: options.MemoryStreamCutoff);
                         }
                     }
                     else if (filename.Equals('/'))
@@ -154,11 +150,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 CopyStreamBytes(fileEntry.Content, entryStream, innerSize);
-                                var entry2 = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                                if (options.FileNamePasses(entry2.FullPath))
-                                {
-                                    yield return entry2;
-                                }
+                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -231,11 +223,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     (Stream)new MemoryStream((int)innerSize);
                                 CopyStreamBytes(fileEntry.Content, entryStream, innerSize);
 
-                                var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                                if (options.FileNamePasses(entry.FullPath))
-                                {
-                                    yield return entry;
-                                }
+                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -258,11 +246,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
 
-                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                        if (options.FileNamePasses(entry.FullPath))
-                        {
-                            yield return entry;
-                        }
+                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true); ;
                     }
                     else
                     {
@@ -271,11 +255,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
 
-                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                        if (options.FileNamePasses(entry.FullPath))
-                        {
-                            yield return entry;
-                        }
+                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                     }
                 }
                 else
@@ -359,11 +339,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             // The name length is included in the total size reported in the header
                             await CopyStreamBytesAsync(fileEntry.Content, entryStream, size - nameLength).ConfigureAwait(false);
 
-                            var entry = new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true);
-                            if (options.FileNamePasses(entry.FullPath))
-                            {
-                                yield return entry;
-                            }
+                            yield return new FileEntry(Encoding.ASCII.GetString(nameSpan).TrimEnd('/'), entryStream, fileEntry, true);
                         }
                     }
                     else if (filename.Equals('/'))
@@ -430,11 +406,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize).ConfigureAwait(false);
-                                var entry2 = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                                if (options.FileNamePasses(entry2.FullPath))
-                                {
-                                    yield return entry2;
-                                }
+                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -507,11 +479,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize).ConfigureAwait(false);
-                                var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                                if (options.FileNamePasses(entry.FullPath))
-                                {
-                                    yield return entry;
-                                }
+                                yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                             }
                         }
                         fileEntry.Content.Position = fileEntry.Content.Length - 1;
@@ -533,11 +501,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
-                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                        if (options.FileNamePasses(entry.FullPath))
-                        {
-                            yield return entry;
-                        }
+                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                     }
                     else
                     {
@@ -545,11 +509,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
                         await CopyStreamBytesAsync(fileEntry.Content, entryStream, size).ConfigureAwait(false);
-                        var entry = new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
-                        if (options.FileNamePasses(entry.FullPath))
-                        {
-                            yield return entry;
-                        }
+                        yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
                     }
                 }
                 else

--- a/RecursiveExtractor/DebArchiveFile.cs
+++ b/RecursiveExtractor/DebArchiveFile.cs
@@ -40,11 +40,8 @@ namespace Microsoft.CST.RecursiveExtractor
 
                     var entryContent = new byte[fileSize];
                     fileEntry.Content.Read(entryContent, 0, fileSize);
-                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{filename}"))
-                    {
-                        var stream = new MemoryStream(entryContent);
-                        yield return new FileEntry(filename, stream, fileEntry, true);
-                    }
+                    var stream = new MemoryStream(entryContent);
+                    yield return new FileEntry(filename, stream, fileEntry, true);
                 }
                 else
                 {
@@ -83,11 +80,8 @@ namespace Microsoft.CST.RecursiveExtractor
 
                     var entryContent = new byte[fileSize];
                     await fileEntry.Content.ReadAsync(entryContent, 0, fileSize).ConfigureAwait(false);
-                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{filename}"))
-                    {
-                        var stream = new MemoryStream(entryContent);
-                        yield return new FileEntry(filename, stream, fileEntry, true);
-                    }
+                    var stream = new MemoryStream(entryContent);
+                    yield return new FileEntry(filename, stream, fileEntry, true);
                 }
                 else
                 {

--- a/RecursiveExtractor/ExtractionStatusCode.cs
+++ b/RecursiveExtractor/ExtractionStatusCode.cs
@@ -5,6 +5,7 @@ namespace Microsoft.CST.RecursiveExtractor
     public enum ExtractionStatusCode
     {
         Ok,
-        BadArgument
+        BadArgument,
+        Failure
     }
 }

--- a/RecursiveExtractor/ExtractorOptions.cs
+++ b/RecursiveExtractor/ExtractorOptions.cs
@@ -117,10 +117,11 @@ namespace Microsoft.CST.RecursiveExtractor
                     allowed = true;
                 }
             }
-            if (allowed && _denyGlobs.Any(x => x.IsMatch(filename)))
+            if (allowed && _denyGlobs.Any() && _denyGlobs.Any(x => x.IsMatch(filename)))
             {
                 allowed = false;
             }
+
             return allowed;
         }
     }

--- a/RecursiveExtractor/ExtractorOptions.cs
+++ b/RecursiveExtractor/ExtractorOptions.cs
@@ -70,6 +70,11 @@ namespace Microsoft.CST.RecursiveExtractor
         public Dictionary<Regex, List<string>> Passwords { get; set; } = new Dictionary<Regex, List<string>>();
 
         /// <summary>
+        /// Should extraction recurse into archives
+        /// </summary>
+        public bool Recurse { get; set; } = true;
+
+        /// <summary>
         /// If set, only return files that match these glob filters
         /// </summary>
         public IEnumerable<string> AllowFilters
@@ -117,10 +122,6 @@ namespace Microsoft.CST.RecursiveExtractor
                 allowed = false;
             }
             return allowed;
-        }
-
-        public ExtractorOptions()
-        {
         }
     }
 }

--- a/RecursiveExtractor/Extractors/AsyncExtractorInterface.cs
+++ b/RecursiveExtractor/Extractors/AsyncExtractorInterface.cs
@@ -4,6 +4,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 {
     public interface AsyncExtractorInterface : ExtractorInterface
     {
-        public IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor);
+        public IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true);
     }
 }

--- a/RecursiveExtractor/Extractors/BZip2Extractor.cs
+++ b/RecursiveExtractor/Extractors/BZip2Extractor.cs
@@ -45,12 +45,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
             if (entry != null)
             {
-                if (Extractor.IsQuine(entry))
-                {
-                    Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                    throw new OverflowException();
-                }
-
                 if (options.Recurse || topLevel)
                 {
                     await foreach (var extractedFile in Context.ExtractAsync(entry, options, governor, false))
@@ -90,12 +84,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
             if (entry != null)
             {
-                if (Extractor.IsQuine(entry))
-                {
-                    Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                    throw new OverflowException();
-                }
-
                 if (options.Recurse || topLevel)
                 {
                     foreach (var extractedFile in Context.Extract(entry, options, governor, false))

--- a/RecursiveExtractor/Extractors/DiscCommon.cs
+++ b/RecursiveExtractor/Extractors/DiscCommon.cs
@@ -40,8 +40,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             {
                 using var fs = fsInfo.Open(volume);
                 var diskFiles = fs.GetFiles(fs.Root.FullName, "*.*", SearchOption.AllDirectories).ToList();
-                diskFiles = options.Recurse ? diskFiles :
-                            diskFiles.Where(x => options.FileNamePasses($"{parent?.FullPath}{Path.DirectorySeparatorChar}{x}")).ToList();
 
                 foreach (var file in diskFiles)
                 {
@@ -129,9 +127,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
                         governor.CheckResourceGovernor(totalLength);
 
-                        var validFileInfos = options.Recurse ? fileinfos :
-                            fileinfos.Where(x => options.FileNamePasses($"{parent?.FullPath}{Path.DirectorySeparatorChar}{x.name}"));
-
                         fileinfos.AsParallel().ForAll(file =>
                         {
                             if (file.stream != null)
@@ -169,10 +164,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         try
                         {
                             var fi = fs.GetFileInfo(file);
-                            if (!options.FileNamePasses(fi.FullName) && !options.Recurse)
-                            {
-                                continue;
-                            }
                             governor.CheckResourceGovernor(fi.Length);
                             fileStream = fi.OpenRead();
                             creation = fi.CreationTime;

--- a/RecursiveExtractor/Extractors/ExtractorInterface.cs
+++ b/RecursiveExtractor/Extractors/ExtractorInterface.cs
@@ -14,6 +14,6 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// <param name="options">The ExtractorOptions to use</param>
         /// <param name="governor">The ResourceGovernor to use</param>
         /// <returns></returns>
-        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor);
+        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true);
     }
 }

--- a/RecursiveExtractor/Extractors/GzipExtractor.cs
+++ b/RecursiveExtractor/Extractors/GzipExtractor.cs
@@ -93,7 +93,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
             var entry = new FileEntry(newFilename, fs, fileEntry);
 
-            if (entry != null && options.FileNamePasses(entry.FullPath))
+            if (entry != null)
             {
                 if (options.Recurse || topLevel)
                 {

--- a/RecursiveExtractor/Extractors/GzipExtractor.cs
+++ b/RecursiveExtractor/Extractors/GzipExtractor.cs
@@ -28,7 +28,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>
         /// <returns> Extracted files </returns>
-        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
 
@@ -51,15 +51,16 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
             if (entry != null)
             {
-                if (Extractor.IsQuine(entry))
+                if (options.Recurse || topLevel)
                 {
-                    Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                    throw new OverflowException();
+                    await foreach (var newFileEntry in Context.ExtractAsync(entry, options, governor, false))
+                    {
+                        yield return newFileEntry;
+                    }
                 }
-
-                await foreach (var extractedFile in Context.ExtractAsync(entry, options, governor))
+                else
                 {
-                    yield return extractedFile;
+                    yield return entry;
                 }
             }
         }
@@ -70,7 +71,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>
         /// <returns> Extracted files </returns>
-        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
 
@@ -94,15 +95,16 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
             if (entry != null && options.FileNamePasses(entry.FullPath))
             {
-                if (Extractor.IsQuine(entry))
+                if (options.Recurse || topLevel)
                 {
-                    Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                    throw new OverflowException();
+                    foreach (var extractedFile in Context.Extract(entry, options, governor, false))
+                    {
+                        yield return extractedFile;
+                    }
                 }
-
-                foreach (var extractedFile in Context.Extract(entry, options, governor))
+                else
                 {
-                    yield return extractedFile;
+                    yield return entry;
                 }
             }
         }

--- a/RecursiveExtractor/Extractors/IsoExtractor.cs
+++ b/RecursiveExtractor/Extractors/IsoExtractor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var cd = new CDReader(fileEntry.Content, true);
-            var entries = cd.Root.GetFiles("*.*", SearchOption.AllDirectories).Where(x => options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{x.FullName}")).ToArray();
+            var entries = cd.Root.GetFiles("*.*", SearchOption.AllDirectories).ToArray();
             if (entries != null)
             {
                 foreach (var file in entries)
@@ -84,7 +84,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var cd = new CDReader(fileEntry.Content, true);
-            var entries = cd.Root.GetFiles("*.*", SearchOption.AllDirectories).Where(x => options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{x.FullName}")).ToArray();
+            var entries = cd.Root.GetFiles("*.*", SearchOption.AllDirectories).ToArray();
             if (entries != null)
             {
                 if (options.Parallel)

--- a/RecursiveExtractor/Extractors/VhdExtractor.cs
+++ b/RecursiveExtractor/Extractors/VhdExtractor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var disk = new DiscUtils.Vhd.Disk(fileEntry.Content, Ownership.None);
             LogicalVolumeInfo[]? logicalVolumes = null;
@@ -46,7 +46,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             {
                 foreach (var volume in logicalVolumes)
                 {
-                    await foreach (var entry in DiscCommon.DumpLogicalVolumeAsync(volume, fileEntry.FullPath, options, governor, Context, fileEntry))
+                    await foreach (var entry in DiscCommon.DumpLogicalVolumeAsync(volume, fileEntry.FullPath, options, governor, Context, fileEntry, topLevel))
                     {
                         yield return entry;
                     }
@@ -66,7 +66,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var disk = new DiscUtils.Vhd.Disk(fileEntry.Content, Ownership.None);
             LogicalVolumeInfo[]? logicalVolumes = null;
@@ -85,7 +85,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             {
                 foreach (var volume in logicalVolumes)
                 {
-                    foreach (var entry in DiscCommon.DumpLogicalVolume(volume, fileEntry.FullPath, options, governor, Context, fileEntry))
+                    foreach (var entry in DiscCommon.DumpLogicalVolume(volume, fileEntry.FullPath, options, governor, Context, fileEntry, topLevel))
                     {
                         yield return entry;
                     }

--- a/RecursiveExtractor/Extractors/VhdxExtractor.cs
+++ b/RecursiveExtractor/Extractors/VhdxExtractor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var disk = new DiscUtils.Vhdx.Disk(fileEntry.Content, Ownership.None);
             LogicalVolumeInfo[]? logicalVolumes = null;
@@ -48,7 +48,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 {
                     var fsInfos = FileSystemManager.DetectFileSystems(volume);
 
-                    await foreach (var entry in DiscCommon.DumpLogicalVolumeAsync(volume, fileEntry.FullPath, options, governor, Context, fileEntry))
+                    await foreach (var entry in DiscCommon.DumpLogicalVolumeAsync(volume, fileEntry.FullPath, options, governor, Context, fileEntry, topLevel))
                     {
                         yield return entry;
                     }
@@ -68,7 +68,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var disk = new DiscUtils.Vhdx.Disk(fileEntry.Content, Ownership.None);
             LogicalVolumeInfo[]? logicalVolumes = null;
@@ -89,7 +89,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                 {
                     var fsInfos = FileSystemManager.DetectFileSystems(volume);
 
-                    foreach (var entry in DiscCommon.DumpLogicalVolume(volume, fileEntry.FullPath, options, governor, Context, fileEntry))
+                    foreach (var entry in DiscCommon.DumpLogicalVolume(volume, fileEntry.FullPath, options, governor, Context, fileEntry, topLevel))
                     {
                         yield return entry;
                     }

--- a/RecursiveExtractor/Extractors/VmdkExtractor.cs
+++ b/RecursiveExtractor/Extractors/VmdkExtractor.cs
@@ -27,7 +27,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var disk = new DiscUtils.Vmdk.Disk(fileEntry.Content, Ownership.None);
             LogicalVolumeInfo[]? logicalVolumes = null;
@@ -46,7 +46,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             {
                 foreach (var volume in logicalVolumes)
                 {
-                    await foreach (var entry in DiscCommon.DumpLogicalVolumeAsync(volume, fileEntry.FullPath, options, governor, Context, fileEntry))
+                    await foreach (var entry in DiscCommon.DumpLogicalVolumeAsync(volume, fileEntry.FullPath, options, governor, Context, fileEntry, topLevel))
                     {
                         yield return entry;
                     }
@@ -66,7 +66,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> </param>
         /// <returns> </returns>
-        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             using var disk = new DiscUtils.Vmdk.Disk(fileEntry.Content, Ownership.None);
             LogicalVolumeInfo[]? logicalVolumes = null;
@@ -85,7 +85,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             {
                 foreach (var volume in logicalVolumes)
                 {
-                    foreach (var entry in DiscCommon.DumpLogicalVolume(volume, fileEntry.FullPath, options, governor, Context, fileEntry))
+                    foreach (var entry in DiscCommon.DumpLogicalVolume(volume, fileEntry.FullPath, options, governor, Context, fileEntry, topLevel))
                     {
                         yield return entry;
                     }

--- a/RecursiveExtractor/Extractors/XzExtractor.cs
+++ b/RecursiveExtractor/Extractors/XzExtractor.cs
@@ -42,36 +42,33 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             if (xzStream != null)
             {
                 var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
-                if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{newFilename}"))
+                var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
+
+                // SharpCompress does not expose metadata without a full read, so we need to decompress first,
+                // and then abort if the bytes exceeded the governor's capacity.
+
+                var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
+                                            .Aggregate((ulong?)0, (a, b) => a + b);
+
+                // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
+                // low risk.
+                if (streamLength.HasValue)
                 {
-                    var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
+                    governor.CheckResourceGovernor((long)streamLength.Value);
+                }
 
-                    // SharpCompress does not expose metadata without a full read, so we need to decompress first,
-                    // and then abort if the bytes exceeded the governor's capacity.
-
-                    var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
-                                              .Aggregate((ulong?)0, (a, b) => a + b);
-
-                    // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
-                    // low risk.
-                    if (streamLength.HasValue)
+                if (newFileEntry != null)
+                {
+                    if (options.Recurse || topLevel)
                     {
-                        governor.CheckResourceGovernor((long)streamLength.Value);
+                        await foreach (var innerEntry in Context.ExtractAsync(newFileEntry, options, governor, false))
+                        {
+                            yield return innerEntry;
+                        }
                     }
-
-                    if (newFileEntry != null)
+                    else
                     {
-                        if (options.Recurse || topLevel)
-                        {
-                            await foreach (var innerEntry in Context.ExtractAsync(newFileEntry, options, governor, false))
-                            {
-                                yield return innerEntry;
-                            }
-                        }
-                        else
-                        {
-                            yield return newFileEntry;
-                        }
+                        yield return newFileEntry;
                     }
                 }
                 xzStream.Dispose();
@@ -104,34 +101,31 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
             if (xzStream != null)
             {
                 var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
-                if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{newFilename}"))
+                var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
+
+                // SharpCompress does not expose metadata without a full read, so we need to decompress first,
+                // and then abort if the bytes exceeded the governor's capacity.
+
+                var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
+                                            .Aggregate((ulong?)0, (a, b) => a + b);
+
+                // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
+                // low risk.
+                if (streamLength.HasValue)
                 {
-                    var newFileEntry = new FileEntry(newFilename, xzStream, fileEntry, memoryStreamCutoff: options.MemoryStreamCutoff);
+                    governor.CheckResourceGovernor((long)streamLength.Value);
+                }
 
-                    // SharpCompress does not expose metadata without a full read, so we need to decompress first,
-                    // and then abort if the bytes exceeded the governor's capacity.
-
-                    var streamLength = xzStream.Index?.Records?.Select(r => r.UncompressedSize)
-                                              .Aggregate((ulong?)0, (a, b) => a + b);
-
-                    // BUG: Technically, we're casting a ulong to a long, but we don't expect 9 exabyte steams, so
-                    // low risk.
-                    if (streamLength.HasValue)
+                if (options.Recurse || topLevel)
+                {
+                    foreach (var innerEntry in Context.Extract(newFileEntry, options, governor, false))
                     {
-                        governor.CheckResourceGovernor((long)streamLength.Value);
+                        yield return innerEntry;
                     }
-
-                    if (options.Recurse || topLevel)
-                    {
-                        foreach (var innerEntry in Context.Extract(newFileEntry, options, governor, false))
-                        {
-                            yield return innerEntry;
-                        }
-                    }
-                    else
-                    {
-                        yield return newFileEntry;
-                    }
+                }
+                else
+                {
+                    yield return newFileEntry;
                 }
                 xzStream.Dispose();
             }

--- a/RecursiveExtractor/Extractors/ZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/ZipExtractor.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>
         /// <returns> Extracted files </returns>
-        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             ZipFile? zipFile = null;
             try
@@ -98,15 +98,19 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     {
                         var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                        if (Extractor.IsQuine(newFileEntry))
+                        if (newFileEntry != null)
                         {
-                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                            throw new OverflowException();
-                        }
-
-                        await foreach (var extractedFile in Context.ExtractAsync(newFileEntry, options, governor))
-                        {
-                            yield return extractedFile;
+                            if (options.Recurse || topLevel)
+                            {
+                                await foreach (var innerEntry in Context.ExtractAsync(newFileEntry, options, governor, false))
+                                {
+                                    yield return innerEntry;
+                                }
+                            }
+                            else
+                            {
+                                yield return newFileEntry;
+                            }
                         }
                     }
                 }
@@ -118,7 +122,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// </summary>
         /// <param name="fileEntry"> FileEntry to extract </param>
         /// <returns> Extracted files </returns>
-        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor)
+        public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
             ZipFile? zipFile = null;
             try
@@ -166,15 +170,16 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     {
                         var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                        if (Extractor.IsQuine(newFileEntry))
+                        if (options.Recurse || topLevel)
                         {
-                            Logger.Info(Extractor.IS_QUINE_STRING, fileEntry.Name, fileEntry.FullPath);
-                            throw new OverflowException();
+                            foreach (var innerEntry in Context.Extract(newFileEntry, options, governor, false))
+                            {
+                                yield return innerEntry;
+                            }
                         }
-
-                        foreach (var extractedFile in Context.Extract(newFileEntry, options, governor))
+                        else
                         {
-                            yield return extractedFile;
+                            yield return newFileEntry;
                         }
                     }
                 }

--- a/RecursiveExtractor/Extractors/ZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/ZipExtractor.cs
@@ -94,23 +94,20 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     }
 
                     var name = zipEntry.Name.Replace('/', Path.DirectorySeparatorChar);
-                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
-                    {
-                        var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                    var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                        if (newFileEntry != null)
+                    if (newFileEntry != null)
+                    {
+                        if (options.Recurse || topLevel)
                         {
-                            if (options.Recurse || topLevel)
+                            await foreach (var innerEntry in Context.ExtractAsync(newFileEntry, options, governor, false))
                             {
-                                await foreach (var innerEntry in Context.ExtractAsync(newFileEntry, options, governor, false))
-                                {
-                                    yield return innerEntry;
-                                }
+                                yield return innerEntry;
                             }
-                            else
-                            {
-                                yield return newFileEntry;
-                            }
+                        }
+                        else
+                        {
+                            yield return newFileEntry;
                         }
                     }
                 }
@@ -166,21 +163,18 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     }
 
                     var name = zipEntry.Name.Replace('/', Path.DirectorySeparatorChar);
-                    if (options.FileNamePasses($"{fileEntry.FullPath}{Path.DirectorySeparatorChar}{name}"))
-                    {
-                        var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
+                    var newFileEntry = new FileEntry(name, fs, fileEntry, modifyTime: zipEntry.DateTime, memoryStreamCutoff: options.MemoryStreamCutoff);
 
-                        if (options.Recurse || topLevel)
+                    if (options.Recurse || topLevel)
+                    {
+                        foreach (var innerEntry in Context.Extract(newFileEntry, options, governor, false))
                         {
-                            foreach (var innerEntry in Context.Extract(newFileEntry, options, governor, false))
-                            {
-                                yield return innerEntry;
-                            }
+                            yield return innerEntry;
                         }
-                        else
-                        {
-                            yield return newFileEntry;
-                        }
+                    }
+                    else
+                    {
+                        yield return newFileEntry;
                     }
                 }
             }

--- a/RecursiveExtractor/RecursiveExtractor.csproj
+++ b/RecursiveExtractor/RecursiveExtractor.csproj
@@ -25,24 +25,24 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DiscUtils.Btrfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Core" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Ext" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Fat" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.HfsPlus" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Iso9660" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Ntfs" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Vhd" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Vhdx" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Vmdk" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Wim" Version="0.15.1-ci0002" />
-    <PackageReference Include="DiscUtils.Xfs" Version="0.15.1-ci0002" />
+    <PackageReference Include="DiscUtils.Btrfs" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Core" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Ext" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Fat" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.HfsPlus" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Iso9660" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Ntfs" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Vhd" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Vhdx" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Vmdk" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Wim" Version="0.16.4" />
+    <PackageReference Include="DiscUtils.Xfs" Version="0.16.4" />
     <PackageReference Include="Glob" Version="1.1.8" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="5.0.0" />
-    <PackageReference Include="NLog" Version="4.7.9" />
+    <PackageReference Include="NLog" Version="4.7.10" />
     <PackageReference Include="SharpCompress" Version="0.28.2" />
     <PackageReference Include="SharpZipLib" Version="1.3.2" />
-    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.194">
+    <PackageReference Include="Nerdbank.GitVersioning" Version="3.4.205">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1-beta",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1-beta",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Simplify file filtering
Fix #55 - now use globs for CLI filtering
SemVer relevant change to 1.1.