### PR TITLE
Add direct ref to Newtonsoft.Json 13.x, remove duplicate PackageRef.

### DIFF
--- a/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
+++ b/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
@@ -13,10 +13,10 @@
     <PackageReference Include="DiscUtils.HfsPlus" Version="0.16.13" />
     <PackageReference Include="DiscUtils.SquashFs" Version="0.16.13" />
     <PackageReference Include="DiscUtils.Xfs" Version="0.16.13" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR has two changes:

1. Explicitly references `Newtonsoft.Json` 13.0.1. Otherwise, `Microsoft.NET.Test.Sdk` and/or `MSTest.TestAdapter` wind up bringing in 10.0.3 which is vulnerable to [GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr). This change is intended to mitigate that risk.
2. We had a duplicate PackageReference to two different versions of `Microsoft.NET.Test.Sdk`. I removed the older reference.