### PR TITLE
Update FileEntry.cs

### DIFF
--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -52,11 +52,11 @@ namespace Microsoft.CST.RecursiveExtractor
                 FullPath = $"{ParentPath}{Path.DirectorySeparatorChar}{name}";
             }
             var printPath = FullPath;
-            if (FullPath.Contains(".."))
+            if (FullPath.Contains("..") || FullPath.Contains(":"))
             {
                 Logger.Info("ZipSlip detected in {0}. Removing unsafe path elements and extracting.", FullPath);
                 // Replace .. for ZipSlip - https://snyk.io/research/zip-slip-vulnerability
-                FullPath = FullPath.Replace("..", "");
+                FullPath = FullPath.Replace("..", "").Replace(":", "");
                 var doubleSeparator = $"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}";
                 while (FullPath.Contains(doubleSeparator))
                 {


### PR DESCRIPTION
Some VHD image file names may include "colon" so ":" char and as it is known the filesystem will not allow it and so it must be removed.