### PR TITLE
Fix invalid paths when calling the extract to disk methods.

### DIFF
--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -436,11 +436,11 @@ namespace Microsoft.CST.RecursiveExtractor
                     Parallel.ForEach(Extract(fileEntry, opts), new ParallelOptions() { CancellationToken = cts.Token }, entry =>
                     {
                         var targetPath = Path.Combine(outputDirectory, entry.FullPath);
-                        if (Path.GetDirectoryName(targetPath) is string directoryPath && targetPath is string targetPathNotNull)
+                        if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                         {
                             try
                             {
-                                Directory.CreateDirectory(directoryPath);
+                                Directory.CreateDirectory(directoryPathNotNull);
 
                                 using var fs = new FileStream(targetPathNotNull, FileMode.Create);
                                 entry.Content.CopyTo(fs);
@@ -519,13 +519,13 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 if (opts?.FileNamePasses(entry.FullPath) ?? true)
                 {
-                    var targetPath = Path.Combine(outputDirectory, entry.FullPath);
-                    if (Path.GetDirectoryName(targetPath) is string directoryPath && targetPath is string targetPathNotNull)
+                    var targetPath = Path.Combine(outputDirectory, invalidChars.Replace(entry.FullPath,"_"));
+                    if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {
                         try
                         {
-                            Directory.CreateDirectory(invalidChars.Replace(directoryPath,"_"));
-                            using var fs = new FileStream(invalidChars.Replace(targetPathNotNull,"_"), FileMode.Create);
+                            Directory.CreateDirectory(directoryPathNotNull);
+                            using var fs = new FileStream(targetPathNotNull, FileMode.Create);
                             await entry.Content.CopyToAsync(fs).ConfigureAwait(false);
                             if (printNames)
                             {

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -383,7 +383,7 @@ namespace Microsoft.CST.RecursiveExtractor
             return ExtractToDirectory(outputDirectory, fileEntry, opts, printNames);
         }
 
-        private static Regex invalidChars = new Regex($"[{Path.GetInvalidPathChars()}");
+        private static Regex invalidChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidPathChars()))));
         
         /// <summary>
         /// Extract the given FileEntry to the given Directory.
@@ -399,14 +399,14 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 foreach (var entry in Extract(fileEntry, opts))
                 {
-                    var targetPath = Path.Combine(outputDirectory, entry.FullPath);
+                    var targetPath = Path.Combine(outputDirectory, invalidChars.Replace(entry.FullPath,"_"));
                     if (Path.GetDirectoryName(targetPath) is string directoryPathNotNull && targetPath is string targetPathNotNull)
                     {
                         try
                         {
-                            Directory.CreateDirectory(invalidChars.Replace(directoryPathNotNull,"_"));
+                            Directory.CreateDirectory(directoryPathNotNull);
 
-                            using var fs = new FileStream(invalidChars.Replace(targetPathNotNull,"_"), FileMode.Create);
+                            using var fs = new FileStream(targetPathNotNull, FileMode.Create);
                             entry.Content.CopyTo(fs);
                             if (printNames)
                             {

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -383,6 +383,8 @@ namespace Microsoft.CST.RecursiveExtractor
             return ExtractToDirectory(outputDirectory, fileEntry, opts, printNames);
         }
 
+        private static Regex invalidChars = new Regex($"[{Path.GetInvalidPathChars()}");
+        
         /// <summary>
         /// Extract the given FileEntry to the given Directory.
         /// </summary>
@@ -398,13 +400,13 @@ namespace Microsoft.CST.RecursiveExtractor
                 foreach (var entry in Extract(fileEntry, opts))
                 {
                     var targetPath = Path.Combine(outputDirectory, entry.FullPath);
-                    if (Path.GetDirectoryName(targetPath) is string directoryPath && targetPath is string targetPathNotNull)
+                    if (Path.GetDirectoryName(targetPath) is string directoryPathNotNull && targetPath is string targetPathNotNull)
                     {
                         try
                         {
-                            Directory.CreateDirectory(directoryPath);
+                            Directory.CreateDirectory(invalidChars.Replace(directoryPathNotNull,"_"));
 
-                            using var fs = new FileStream(targetPathNotNull, FileMode.Create);
+                            using var fs = new FileStream(invalidChars.Replace(targetPathNotNull,"_"), FileMode.Create);
                             entry.Content.CopyTo(fs);
                             if (printNames)
                             {
@@ -522,8 +524,8 @@ namespace Microsoft.CST.RecursiveExtractor
                     {
                         try
                         {
-                            Directory.CreateDirectory(directoryPath);
-                            using var fs = new FileStream(targetPathNotNull, FileMode.Create);
+                            Directory.CreateDirectory(invalidChars.Replace(directoryPath,"_"));
+                            using var fs = new FileStream(invalidChars.Replace(targetPathNotNull,"_"), FileMode.Create);
                             await entry.Content.CopyToAsync(fs).ConfigureAwait(false);
                             if (printNames)
                             {


### PR DESCRIPTION
Fixes the issue reported in #88 when extracting files containing invalid path characters to disc.