### PR TITLE
Also fix invalid filename chars separately from invalid path chars

### DIFF
--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -18,17 +18,26 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
     public class SanitizePathTests
     {
         [DataTestMethod]
-        [DataRow("a/file/with:colon.name", "a/file/with_colon.name", "a\\file\\with_colon.name")]
-        [DataRow("a/folder:with/colon.name", "a/folder_with/colon.name", "a\\folder_with\\colon.name")]
+        [DataRow("a\\file\\with:colon.name", "a\\file\\with_colon.name")]
+        [DataRow("a\\folder:with\\colon.name", "a\\folder_with\\colon.name")]
 
-        public void TestSanitizePath(string inputPath, string expectedLinuxPath, string expectedWindowsPath)
+        public void TestSanitizePathWindows(string windowsInputPath, string expectedWindowsPath)
         {
-            var entry = new FileEntry(inputPath, Stream.Null);
+            var entry = new FileEntry(windowsInputPath, Stream.Null);
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Assert.AreEqual(expectedWindowsPath, entry.GetSanitizedPath());
             }
-            else
+        }
+        
+        [DataTestMethod]
+        [DataRow("a/file/with:colon.name", "a/file/with_colon.name")]
+        [DataRow("a/folder:with/colon.name", "a/folder_with/colon.name")]
+
+        public void TestSanitizePathLinux(string linuxInputPath, string expectedLinuxPath)
+        {
+            var entry = new FileEntry(linuxInputPath, Stream.Null);
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 Assert.AreEqual(expectedLinuxPath, entry.GetSanitizedPath());
             }

--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NLog;
+using NLog.Config;
+using NLog.Targets;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace Microsoft.CST.RecursiveExtractor.Tests
+{
+    [TestClass]
+    public class SanitizePathTests
+    {
+        [DataTestMethod]
+        [DataRow("a/file/with:colon.name", "a/file/with_colon.name", "a\\file\\with_colon.name")]
+        [DataRow("a/folder:with/colon.name", "a/folder_with/colon.name", "a\\folder_with\\colon.name")]
+
+        public void TestSanitizePath(string inputPath, string expectedLinuxPath, string expectedWindowsPath)
+        {
+            var entry = new FileEntry(inputPath, Stream.Null);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.AreEqual(expectedWindowsPath, entry.GetSanitizedPath());
+            }
+            else
+            {
+                Assert.AreEqual(expectedLinuxPath, entry.GetSanitizedPath());
+            }
+        }
+
+        protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
+    }
+}

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -383,8 +383,9 @@ namespace Microsoft.CST.RecursiveExtractor
             return ExtractToDirectory(outputDirectory, fileEntry, opts, printNames);
         }
 
-        private static Regex invalidChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidPathChars()))));
-        
+        private static Regex invalidPathChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidPathChars()))));
+        private static Regex invalidFileChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidFileNameChars()))));
+
         /// <summary>
         /// Extract the given FileEntry to the given Directory.
         /// </summary>
@@ -399,9 +400,12 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 foreach (var entry in Extract(fileEntry, opts))
                 {
-                    var targetPath = Path.Combine(outputDirectory, invalidChars.Replace(entry.FullPath,"_"));
-                    if (Path.GetDirectoryName(targetPath) is string directoryPathNotNull && targetPath is string targetPathNotNull)
+                    var targetPath = Path.Combine(outputDirectory, invalidPathChars.Replace(entry.FullPath,"_"));
+                    
+                    if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {
+                        targetPathNotNull = Path.Combine(directoryPathNotNull,
+                            invalidFileChars.Replace(targetPathNotNull, "_"));
                         try
                         {
                             Directory.CreateDirectory(directoryPathNotNull);
@@ -435,9 +439,11 @@ namespace Microsoft.CST.RecursiveExtractor
                 {
                     Parallel.ForEach(Extract(fileEntry, opts), new ParallelOptions() { CancellationToken = cts.Token }, entry =>
                     {
-                        var targetPath = Path.Combine(outputDirectory, entry.FullPath);
+                        var targetPath = Path.Combine(outputDirectory, invalidPathChars.Replace(entry.FullPath,"_"));
                         if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                         {
+                            targetPathNotNull = Path.Combine(directoryPathNotNull,
+                                invalidFileChars.Replace(targetPathNotNull, "_"));
                             try
                             {
                                 Directory.CreateDirectory(directoryPathNotNull);
@@ -519,9 +525,11 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 if (opts?.FileNamePasses(entry.FullPath) ?? true)
                 {
-                    var targetPath = Path.Combine(outputDirectory, invalidChars.Replace(entry.FullPath,"_"));
+                    var targetPath = Path.Combine(outputDirectory, invalidPathChars.Replace(entry.FullPath,"_"));
                     if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {
+                        targetPathNotNull = Path.Combine(directoryPathNotNull,
+                            invalidFileChars.Replace(targetPathNotNull, "_"));
                         try
                         {
                             Directory.CreateDirectory(directoryPathNotNull);

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -398,8 +398,7 @@ namespace Microsoft.CST.RecursiveExtractor
                 foreach (var entry in Extract(fileEntry, opts))
                 {
                     var targetPath = Path.Combine(outputDirectory, entry.GetSanitizedPath());
-                    if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull &&
-                        targetPath is { } targetPathNotNull)
+                    if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {
                         try
                         {
@@ -411,7 +410,6 @@ namespace Microsoft.CST.RecursiveExtractor
                             {
                                 Console.WriteLine("Extracted {0}.", entry.FullPath);
                             }
-
                             Logger.Trace("Extracted {0}", entry.FullPath);
                         }
                         catch (Exception e)
@@ -522,8 +520,7 @@ namespace Microsoft.CST.RecursiveExtractor
                 {
                     var targetPath = Path.Combine(outputDirectory, entry.GetSanitizedPath());
 
-                    if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull &&
-                        targetPath is { } targetPathNotNull)
+                    if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {
                         try
                         {
@@ -534,7 +531,6 @@ namespace Microsoft.CST.RecursiveExtractor
                             {
                                 Console.WriteLine("Extracted {0}.", entry.FullPath);
                             }
-
                             Logger.Trace("Extracted {0}", entry.FullPath);
                         }
                         catch (Exception e)

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -197,6 +197,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <summary>
         /// Sanitizes the <see cref="FullPath"/> from the values of <see cref="Path.GetInvalidFileNameChars"/>. Leveraged by the ExtractToDirectory methods of <see cref="Extractor"/>
         /// </summary>
+        /// <param name="replacement">The string value to replace any invalid characters with</param>
         /// <returns>A sanitized path suitable to attempt to write to disk.</returns>
         public string GetSanitizedPath(string replacement = "_")
         {

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
@@ -199,16 +200,14 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <returns></returns>
         public string GetSanitizedPath()
         {
-            if (ParentPath is { } parentPath)
+            var bits = FullPath.Split(new[]{"/"}, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < bits.Length - 1; i++)
             {
-                return
-                    Path.Combine(invalidPathChars.Replace(parentPath, "_"),
-                        invalidFileChars.Replace(Name, "_"));
+                bits[i] = invalidFileChars.Replace(bits[i], "_");
             }
-            else
-            {
-                return GetSanitizedName();
-            }
+
+            bits[^1] = invalidFileChars.Replace(bits[^1], "_");
+            return Path.Combine(bits);
         }
 
         /// <summary>

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Microsoft.CST.RecursiveExtractor
@@ -188,7 +189,37 @@ namespace Microsoft.CST.RecursiveExtractor
         /// ExtractionStatus metadata.
         /// </summary>
         public FileEntryStatus EntryStatus { get; set; }
+        
+        private static Regex invalidPathChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidPathChars()))));
+        private static Regex invalidFileChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidFileNameChars()))));
+        
+        /// <summary>
+        /// Returns the full sanitized path of the FileEntry suitable to write to disk
+        /// </summary>
+        /// <returns></returns>
+        public string GetSanitizedPath()
+        {
+            if (ParentPath is { } parentPath)
+            {
+                return
+                    Path.Combine(invalidPathChars.Replace(parentPath, "_"),
+                        invalidFileChars.Replace(Name, "_"));
+            }
+            else
+            {
+                return GetSanitizedName();
+            }
+        }
 
+        /// <summary>
+        /// Returns the sanitized filename the FileEntry suitable to write to disk
+        /// </summary>
+        /// <returns></returns>
+        public string GetSanitizedName()
+        {
+            return invalidFileChars.Replace(Name, "_");
+        }
+        
         internal bool Passthrough { get; }
 
         private const int bufferSize = 4096;

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -195,27 +195,18 @@ namespace Microsoft.CST.RecursiveExtractor
         private static Regex invalidFileChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidFileNameChars()))));
         
         /// <summary>
-        /// Returns the full sanitized path of the FileEntry suitable to write to disk
+        /// Sanitizes the <see cref="FullPath"/> from the values of <see cref="Path.GetInvalidFileNameChars"/>. Leveraged by the ExtractToDirectory methods of <see cref="Extractor"/>
         /// </summary>
-        /// <returns></returns>
-        public string GetSanitizedPath()
+        /// <returns>A sanitized path suitable to attempt to write to disk.</returns>
+        public string GetSanitizedPath(string replacement = "_")
         {
             var bits = FullPath.Split(new[]{Path.DirectorySeparatorChar}, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < bits.Length - 1; i++)
             {
-                bits[i] = invalidFileChars.Replace(bits[i], "_");
+                bits[i] = invalidFileChars.Replace(bits[i], replacement);
             }
-            bits[^1] = invalidFileChars.Replace(bits[^1], "_");
+            bits[^1] = invalidFileChars.Replace(bits[^1], replacement);
             return Path.Combine(bits);
-        }
-
-        /// <summary>
-        /// Returns the sanitized filename the FileEntry suitable to write to disk
-        /// </summary>
-        /// <returns></returns>
-        public string GetSanitizedName()
-        {
-            return invalidFileChars.Replace(Name, "_");
         }
         
         internal bool Passthrough { get; }

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -44,13 +44,11 @@ namespace Microsoft.CST.RecursiveExtractor
 
             if (parent == null)
             {
-                ParentPath = null;
                 FullPath = name;
             }
             else
             {
-                ParentPath = parent.FullPath;
-                FullPath = $"{ParentPath}{Path.DirectorySeparatorChar}{name}";
+                FullPath = Path.Combine(parent.FullPath,name);
             }
             var printPath = FullPath;
             if (FullPath.Contains(".."))
@@ -167,7 +165,8 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <summary>
         /// The Path to the parent.
         /// </summary>
-        public string? ParentPath { get; }
+        [Obsolete("You probably want the FullPath property instead. If needed, access the Parent object's FullName directly. May be subject to removal in a future release. ")]
+        public string? ParentPath => Parent?.FullPath;
         /// <summary>
         /// Should the <see cref="Content"/> Stream be disposed when this object is finalized.
         /// Default: true

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -2,7 +2,6 @@
 
 using System;
 using System.IO;
-using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -190,8 +190,8 @@ namespace Microsoft.CST.RecursiveExtractor
         /// </summary>
         public FileEntryStatus EntryStatus { get; set; }
         
-        private static Regex invalidPathChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidPathChars()))));
-        private static Regex invalidFileChars = new Regex(string.Format("[{0}]", Regex.Escape(new string(System.IO.Path.GetInvalidFileNameChars()))));
+        private static readonly Regex InvalidFileChars = new Regex(
+            $"[{Regex.Escape(new string(Path.GetInvalidFileNameChars()))}]");
         
         /// <summary>
         /// Sanitizes the <see cref="FullPath"/> from the values of <see cref="Path.GetInvalidFileNameChars"/>. Leveraged by the ExtractToDirectory methods of <see cref="Extractor"/>
@@ -203,9 +203,9 @@ namespace Microsoft.CST.RecursiveExtractor
             var bits = FullPath.Split(new[]{Path.DirectorySeparatorChar}, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < bits.Length - 1; i++)
             {
-                bits[i] = invalidFileChars.Replace(bits[i], replacement);
+                bits[i] = InvalidFileChars.Replace(bits[i], replacement);
             }
-            bits[^1] = invalidFileChars.Replace(bits[^1], replacement);
+            bits[^1] = InvalidFileChars.Replace(bits[^1], replacement);
             return Path.Combine(bits);
         }
         

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -200,12 +200,11 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <returns></returns>
         public string GetSanitizedPath()
         {
-            var bits = FullPath.Split(new[]{"/"}, StringSplitOptions.RemoveEmptyEntries);
+            var bits = FullPath.Split(new[]{Path.DirectorySeparatorChar}, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < bits.Length - 1; i++)
             {
                 bits[i] = invalidFileChars.Replace(bits[i], "_");
             }
-
             bits[^1] = invalidFileChars.Replace(bits[^1], "_");
             return Path.Combine(bits);
         }


### PR DESCRIPTION
Also cover case of ExtractDirectory with parallel.

Follow up to fix more cases from #89.