### PR TITLE
changed way of generating temporary file path

### DIFF
--- a/RecursiveExtractor.Blazor/Shared/DragnDropInputCommon.razor
+++ b/RecursiveExtractor.Blazor/Shared/DragnDropInputCommon.razor
@@ -217,7 +217,7 @@ else
                     value = e.Position;
                     this.StateHasChanged();
                 };
-                var entryStream = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
+                var entryStream = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
                 await pair.Stream.CopyToAsync(entryStream);
 
                 var entry = await FileEntry.FromStreamAsync(pair.FileInfo.Name, entryStream, null);

--- a/RecursiveExtractor.Tests/CliTests.cs
+++ b/RecursiveExtractor.Tests/CliTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         {
             var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
-            var newpath = Path.GetTempFileName();
+            var newpath = TempPath.GetTempFilePath();
             File.Copy(path, newpath,true);
             RecursiveExtractorClient.ExtractCommand(new ExtractCommandOptions()
             {
@@ -78,7 +78,7 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
         {
             var directory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
-            var newpath = Path.GetTempFileName();
+            var newpath = TempPath.GetTempFilePath();
             File.Copy(path, newpath, true);
             RecursiveExtractorClient.ExtractCommand(new ExtractCommandOptions()
             {

--- a/RecursiveExtractor/ArFile.cs
+++ b/RecursiveExtractor/ArFile.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CST.RecursiveExtractor
 
                             fileEntry.Content.Read(nameSpan, 0, nameLength);
 
-                            var entryStream = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                            var entryStream = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
 
                             // The name length is included in the total size reported in the header
                             CopyStreamBytes(fileEntry.Content, entryStream, size - nameLength);
@@ -147,7 +147,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     filename = entry.Item2;
                                 }
                                 var entryStream = innerSize > options.MemoryStreamCutoff ?
-                                    new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                    new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 CopyStreamBytes(fileEntry.Content, entryStream, innerSize);
                                 yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
@@ -219,7 +219,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     filename = innerEntry.Item2;
                                 }
                                 var entryStream = innerSize > options.MemoryStreamCutoff ?
-                                    new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                    new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 CopyStreamBytes(fileEntry.Content, entryStream, innerSize);
 
@@ -242,7 +242,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             }
                         }
                         var entryStream = size > options.MemoryStreamCutoff ?
-                                    new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                    new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
 
@@ -251,7 +251,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     else
                     {
                         var entryStream = size > options.MemoryStreamCutoff ?
-                                    new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                    new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
 
@@ -333,7 +333,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             await fileEntry.Content.ReadAsync(nameSpan, 0, nameLength).ConfigureAwait(false);
 
                             var entryStream = size - nameLength > options.MemoryStreamCutoff ?
-                                                                new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                                                new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                                                 (Stream)new MemoryStream((int)size - nameLength);
                             // The name length is included in the total size reported in the header
                             await CopyStreamBytesAsync(fileEntry.Content, entryStream, size - nameLength).ConfigureAwait(false);
@@ -402,7 +402,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                     filename = entry.Item2;
                                 }
                                 var entryStream = innerSize > options.MemoryStreamCutoff ?
-                                    new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                    new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize).ConfigureAwait(false);
                                 yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
@@ -475,7 +475,7 @@ namespace Microsoft.CST.RecursiveExtractor
                                 }
 
                                 var entryStream = innerSize > options.MemoryStreamCutoff ?
-                                    new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                                    new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                                     (Stream)new MemoryStream((int)innerSize);
                                 await CopyStreamBytesAsync(fileEntry.Content, entryStream, innerSize).ConfigureAwait(false);
                                 yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
@@ -497,7 +497,7 @@ namespace Microsoft.CST.RecursiveExtractor
                             }
                         }
                         var entryStream = size > options.MemoryStreamCutoff ?
-                            new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                            new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
                         CopyStreamBytes(fileEntry.Content, entryStream, size);
                         yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);
@@ -505,7 +505,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     else
                     {
                         var entryStream = size > options.MemoryStreamCutoff ?
-                            new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
+                            new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose) :
                             (Stream)new MemoryStream((int)size);
                         await CopyStreamBytesAsync(fileEntry.Content, entryStream, size).ConfigureAwait(false);
                         yield return new FileEntry(filename.TrimEnd('/'), entryStream, fileEntry, true);

--- a/RecursiveExtractor/Extractors/BZip2Extractor.cs
+++ b/RecursiveExtractor/Extractors/BZip2Extractor.cs
@@ -32,7 +32,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// <returns> Extracted files </returns>
         public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
-            using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+            using var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
             var failed = false;
             try
             {
@@ -88,7 +88,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         {
             var newFilename = Path.GetFileNameWithoutExtension(fileEntry.Name);
 
-            using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
+            using var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
 
             var failed = false;
 

--- a/RecursiveExtractor/Extractors/GzipExtractor.cs
+++ b/RecursiveExtractor/Extractors/GzipExtractor.cs
@@ -33,7 +33,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// <returns> Extracted files </returns>
         public async IAsyncEnumerable<FileEntry> ExtractAsync(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
-            using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+            using var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
             var failed = false;
             try
             {
@@ -92,7 +92,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
         /// <returns> Extracted files </returns>
         public IEnumerable<FileEntry> Extract(FileEntry fileEntry, ExtractorOptions options, ResourceGovernor governor, bool topLevel = true)
         {
-            using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
+            using var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, 4096, FileOptions.DeleteOnClose);
             var failed = false;
             try
             {

--- a/RecursiveExtractor/Extractors/TarExtractor.cs
+++ b/RecursiveExtractor/Extractors/TarExtractor.cs
@@ -53,7 +53,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         continue;
                     }
 
-                    var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                    var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
                     governor.CheckResourceGovernor(tarEntry.Size);
                     try
                     {
@@ -117,7 +117,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                         continue;
                     }
 
-                    var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                    var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
                     governor.CheckResourceGovernor(tarEntry.Size);
                     try
                     {

--- a/RecursiveExtractor/Extractors/ZipExtractor.cs
+++ b/RecursiveExtractor/Extractors/ZipExtractor.cs
@@ -101,7 +101,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
                     governor.CheckResourceGovernor(zipEntry.Size);
 
-                    using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                    using var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
                     try
                     {
                         using var zipStream = zipFile.GetInputStream(zipEntry);
@@ -170,7 +170,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
 
                     governor.CheckResourceGovernor(zipEntry.Size);
 
-                    using var fs = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                    using var fs = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
 
                     if (zipEntry.IsCrypted && !passwordFound)
                     {

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -78,7 +78,7 @@ namespace Microsoft.CST.RecursiveExtractor
                 {
                     if (inputStream.Length > memoryStreamCutoff)
                     {
-                        Content = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                        Content = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
                     }
                     else
                     {
@@ -87,7 +87,7 @@ namespace Microsoft.CST.RecursiveExtractor
                 }
                 catch (Exception)
                 {
-                    Content = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
+                    Content = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.DeleteOnClose);
                 }
 
                 long? initialPosition = null;
@@ -246,7 +246,7 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 if (content.Length > memoryStreamCutoff)
                 {
-                    Content = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+                    Content = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
                 }
                 else
                 {
@@ -255,7 +255,7 @@ namespace Microsoft.CST.RecursiveExtractor
             }
             catch (Exception)
             {
-                Content = new FileStream(Path.GetTempFileName(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
+                Content = new FileStream(TempPath.GetTempFilePath(), FileMode.Create, FileAccess.ReadWrite, FileShare.ReadWrite, bufferSize, FileOptions.Asynchronous | FileOptions.DeleteOnClose);
             }
 
             long? initialPosition = null;

--- a/RecursiveExtractor/TempPath.cs
+++ b/RecursiveExtractor/TempPath.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
+
+using System.IO;
+
+namespace Microsoft.CST.RecursiveExtractor;
+
+/// <summary>
+/// Helper class to get temporary file path
+/// </summary>
+public static class TempPath
+{
+    /// <summary>
+    /// Use this instead of Path.GetTempFileName()
+    /// Path.GetTempFileName() generates predictable file names and is inherently unreliable and insecure.
+    /// Additionally, the method will raise an IOException if it is used to create more than 65535 files
+    /// without deleting previous temporary files.
+    /// </summary>
+    /// <returns></returns>
+    public static string GetTempFilePath()
+    {
+        return Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+    }
+}


### PR DESCRIPTION
Hi,

Path.GetTempFileName() generates predictable file names and is inherently unreliable and insecure. Additionally, the method will raise an IOException if it is used to create more than 65535 files without deleting previous temporary files.

https://rules.sonarsource.com/csharp/RSPEC-5445