### PR TITLE
Remove 7z Parallel Per Report of Unreliable Behavior

### DIFF
--- a/RecursiveExtractor.Tests/ExtractorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests.cs
@@ -1049,6 +1049,31 @@ namespace Microsoft.CST.RecursiveExtractor.Tests
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "Bombs", fileName);
             _ = extractor.Extract(path, new ExtractorOptions() { MemoryStreamCutoff = 1024 * 1024 * 1024 }).ToList();
         }
+        
+        [DataTestMethod]
+        [DataRow("TestData.zip", 5)]
+        [DataRow("TestData.7z")]
+        [DataRow("TestData.tar", 6)]
+        [DataRow("TestData.rar")]
+        [DataRow("TestData.rar4")]
+        [DataRow("TestData.tar.bz2", 6)]
+        [DataRow("TestData.tar.gz", 6)]
+        [DataRow("TestData.tar.xz")]
+        [DataRow("sysvbanner_1.0-17fakesync1_amd64.deb", 8)]
+        [DataRow("TestData.a")]
+        [DataRow("TestData.bsd.ar")]
+        [DataRow("TestData.iso")]
+        [DataRow("TestData.vhdx")]
+        [DataRow("TestData.wim")]
+        [DataRow("EmptyFile.txt", 1)]
+        [DataRow("TestDataArchivesNested.Zip", 54)]        
+        public void ExtractArchiveSmallBatchSize(string fileName, int expectedNumFiles = 3)
+        {
+            var extractor = new Extractor();
+            var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+            var results = extractor.Extract(path, new ExtractorOptions() { Parallel = true, BatchSize = 2 });
+            Assert.AreEqual(expectedNumFiles, results.Count(entry => entry.EntryStatus == FileEntryStatus.Default));
+        }
 
         [DataTestMethod]
         [DataRow("zip-slip-win.zip")]

--- a/RecursiveExtractor/Extractors/IsoExtractor.cs
+++ b/RecursiveExtractor/Extractors/IsoExtractor.cs
@@ -120,7 +120,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                     var batchSize = Math.Min(options.BatchSize, entries.Length);
                     while (entries.Length > 0)
                     {
-                        var selectedFileEntries = entries.Take(batchSize);
+                        var selectedFileEntries = entries.Take(batchSize).ToArray();
                         var fileInfoTuples = new List<(string name, DateTime created, DateTime modified, DateTime accessed, Stream stream)>();
 
                         foreach (var selectedFileEntry in selectedFileEntries)
@@ -156,7 +156,7 @@ namespace Microsoft.CST.RecursiveExtractor.Extractors
                             }
                         });
 
-                        entries = entries[batchSize..];
+                        entries = entries[selectedFileEntries.Length..];
 
                         while (files.TryPop(out var result))
                         {


### PR DESCRIPTION
Fix Batch method for Iso Extractor #111 
Remove 7z Parallel Implementation due to underlying incompat with SharpCompress #109 