### PR TITLE
Fixes premature sanitization of the name argument to FileEntry

### DIFF
--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -303,7 +303,7 @@ namespace Microsoft.CST.RecursiveExtractor
             {
                 fullPath = fullPath.Replace("..", replacement);
                 var directorySeparator = Path.DirectorySeparatorChar.ToString();
-                var doubleSeparator = $"{directorySeparator},{directorySeparator}");
+                var doubleSeparator = $"{directorySeparator},{directorySeparator}";
                 while (fullPath.Contains(doubleSeparator))
                 {
                     fullPath = fullPath.Replace(doubleSeparator, $"{directorySeparator}");

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -55,6 +55,11 @@ namespace Microsoft.CST.RecursiveExtractor
             // Sanitize the full path so its safe from zip slip
             FullPath = ZipSlipSanitize(FullPath);
 
+            if (printPath != FullPath)
+            {
+                Logger.Info("ZipSlip detected in {Path}. Removing unsafe path elements", printPath);
+            }
+            
             if (inputStream == null)
             {
                 throw new ArgumentNullException(nameof(inputStream));
@@ -291,16 +296,17 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="fullPath">The path to sanitize</param>
         /// <param name="replacement">The string to replace .. with</param>
         /// <returns>A path without ZipSlip</returns>
+        [Pure]
         private static string ZipSlipSanitize(string fullPath, string replacement = "")
         {
             if (fullPath.Contains(".."))
             {
-                Logger.Info("ZipSlip detected in {Path}. Removing unsafe path elements and extracting", fullPath);
                 fullPath = fullPath.Replace("..", replacement);
-                var doubleSeparator = $"{Path.DirectorySeparatorChar}{Path.DirectorySeparatorChar}";
+                var directorySeparator = Path.DirectorySeparatorChar.ToString();
+                var doubleSeparator = $"{directorySeparator},{directorySeparator}");
                 while (fullPath.Contains(doubleSeparator))
                 {
-                    fullPath = fullPath.Replace(doubleSeparator, $"{Path.DirectorySeparatorChar}");
+                    fullPath = fullPath.Replace(doubleSeparator, $"{directorySeparator}");
                 }
             }
 

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -39,8 +39,7 @@ namespace Microsoft.CST.RecursiveExtractor
             ModifyTime = modifyTime ?? DateTime.MinValue;
             AccessTime = accessTime ?? DateTime.MinValue;
 
-            name = SanitizePath(name);
-            Name = Path.GetFileName(name);
+            Name = Path.GetFileName(SanitizePath(name));
 
             FullPath = parent == null ? name : Path.Combine(parent.FullPath,name);
             var printPath = FullPath;

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -41,7 +41,7 @@ namespace Microsoft.CST.RecursiveExtractor
 
             Name = Path.GetFileName(SanitizePath(name));
 
-            FullPath = parent == null ? name : Path.Combine(parent.FullPath,name);
+            FullPath = parent == null ? name : Path.Combine(parent.FullPath,SanitizePath(name));
             var printPath = FullPath;
 
             FullPath = ZipSlipSanitize(FullPath);

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.Contracts;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -39,11 +40,19 @@ namespace Microsoft.CST.RecursiveExtractor
             ModifyTime = modifyTime ?? DateTime.MinValue;
             AccessTime = accessTime ?? DateTime.MinValue;
 
-            Name = Path.GetFileName(SanitizePath(name));
+            // Sanitize so its safe to use with Path APIs
+            string sanitizedName = SanitizePath(name);
+            Name = Path.GetFileName(sanitizedName);
 
-            FullPath = parent == null ? name : Path.Combine(parent.FullPath,SanitizePath(name));
+            // If parent is null use the provided name as the FullPath
+            FullPath = parent == null ? name : 
+                // Otherwise combine the provided name with the full path of the parent
+                Path.Combine(parent.FullPath,sanitizedName);
+            
+            // Stash a copy of the full path for error messages
             var printPath = FullPath;
 
+            // Sanitize the full path so its safe from zip slip
             FullPath = ZipSlipSanitize(FullPath);
 
             if (inputStream == null)
@@ -173,6 +182,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// </summary>
         /// <param name="replacement">The string value to replace any invalid characters with</param>
         /// <returns>A sanitized path suitable to attempt to write to disk.</returns>
+        [Pure]
         public string GetSanitizedPath(string replacement = "_") => SanitizePath(FullPath, replacement);
 
         /// <summary>
@@ -181,6 +191,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="path">Path to Sanitize</param>
         /// <param name="replacement">The replacement character to use for invalid characters</param>
         /// <returns>A sanitized path suitable to write to disk</returns>
+        [Pure]
         public static string SanitizePath(string path, string replacement = "_") => InvalidFileChars.Replace(path, replacement);
         
         internal bool Passthrough { get; }


### PR DESCRIPTION
A file Entry may represent a literal file on disk in which case its FullName representation should be the real path to the file. Sanitization was being performed twice, it is already done in the extract to directory method before writing files out and a method to obtain the sanitized name is provided on the FileEntry object.

The old premature sanitation was added to support Path.Combine on .net48 which doesn't allow characters that are invalid on windows in the Path.Combine command. Compatibility with this is tested in the malformed archives tests and is still retained by sanitizing the name value if it is not being directly used as FullPath.