### PR TITLE
Improve Dispose Behavior on ExtractToDirectory(filename) API

### DIFF
--- a/RecursiveExtractor.Blazor/RecursiveExtractor.Blazor.csproj
+++ b/RecursiveExtractor.Blazor/RecursiveExtractor.Blazor.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="8.0.3" PrivateAssets="all" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
     <PackageReference Include="Tewr.Blazor.FileReader" Version="3.3.2.23201" />
   </ItemGroup>

--- a/RecursiveExtractor.Cli.Tests/RecursiveExtractor.Cli.Tests.csproj
+++ b/RecursiveExtractor.Cli.Tests/RecursiveExtractor.Cli.Tests.csproj
@@ -10,13 +10,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-        <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
-        <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+        <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+        <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RecursiveExtractor.Tests/ExtractorTests/DisposeBehaviorTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests/DisposeBehaviorTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.CST.RecursiveExtractor;
+using Microsoft.CST.RecursiveExtractor.Tests;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System;
 using System.Collections.Generic;
@@ -119,6 +120,53 @@ public class DisposeBehaviorTests : BaseExtractorTestClass
         foreach (var disposedResult in disposedResults)
         {
             Assert.ThrowsException<ObjectDisposedException>(() => disposedResult.Content.Position);
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow("TestData.zip")]
+    public void EnsureDisposedWithExtractToDirectory(string fileName)
+    {
+        var directory = TestPathHelpers.GetFreshTestDirectory();
+        var copyDirectory = TestPathHelpers.GetFreshTestDirectory();
+        Directory.CreateDirectory(copyDirectory);
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+        // Make a copy of the archive so it can be deleted later to confirm properly disposed
+        var copyPath = Path.Combine(copyDirectory, fileName);
+        File.Copy(path, copyPath);
+        var extractor = new Extractor();
+        extractor.ExtractToDirectory(directory, copyPath);
+        File.Delete(copyPath);
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, true);
+        }
+        if (Directory.Exists(copyDirectory)) {
+            Directory.Delete(copyDirectory, true);
+        }
+    }
+
+    [DataTestMethod]
+    [DataRow("TestData.zip")]
+    public async Task EnsureDisposedWithExtractToDirectoryAsync(string fileName)
+    {
+        var directory = TestPathHelpers.GetFreshTestDirectory();
+        var copyDirectory = TestPathHelpers.GetFreshTestDirectory();
+        Directory.CreateDirectory(copyDirectory);
+        var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
+        // Make a copy of the archive so it can be deleted later to confirm properly disposed
+        var copyPath = Path.Combine(copyDirectory, fileName);
+        File.Copy(path, copyPath);
+        var extractor = new Extractor();
+        await extractor.ExtractToDirectoryAsync(directory, copyPath);
+        File.Delete(copyPath);
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, true);
+        }
+        if (Directory.Exists(copyDirectory))
+        {
+            Directory.Delete(copyDirectory, true);
         }
     }
 }

--- a/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
+++ b/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.SquashFs" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.36" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.2.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.SquashFs" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.40" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.3.8" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -381,7 +381,8 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public ExtractionStatusCode ExtractToDirectory(string outputDirectory, string filename, ExtractorOptions? opts = null, bool printNames = false)
         {
-            return ExtractToDirectory(outputDirectory, FileEntry.FromFileName(filename), opts, printNames);
+            using Stream fileStream = File.OpenRead(filename);
+            return ExtractToDirectory(outputDirectory, filename, fileStream, opts, printNames);
         }
 
         /// <summary>
@@ -529,7 +530,8 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public async Task<ExtractionStatusCode> ExtractToDirectoryAsync(string outputDirectory, string filename, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
-            return await ExtractToDirectoryAsync(outputDirectory, FileEntry.FromFileName(filename), opts, acceptFilters, denyFilters, printNames).ConfigureAwait(false);
+            using Stream fileStream = File.OpenRead(filename);
+            return await ExtractToDirectoryAsync(outputDirectory, filename, fileStream, opts, acceptFilters, denyFilters, printNames).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/RecursiveExtractor/RecursiveExtractor.csproj
+++ b/RecursiveExtractor/RecursiveExtractor.csproj
@@ -25,20 +25,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Core" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Dmg" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Ext" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Fat" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Iso9660" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Ntfs" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Udf" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Vhd" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Vhdx" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Vmdk" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Wim" Version="1.0.36" />
-    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.36" />
+    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Core" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Dmg" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Ext" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Fat" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Iso9660" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Ntfs" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Udf" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Vhd" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Vhdx" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Vmdk" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Wim" Version="1.0.40" />
+    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.40" />
     <PackageReference Include="Glob" Version="1.1.9" />
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />


### PR DESCRIPTION
Fix #149.

This API was relying on the FileEntry finalizer to dispose the stream, but the timing of disposal is unreliable and users expect locks to be released after the method returns. This changes the filename based ExtractToDirectory API to create a Stream in the method context and dispose it when leaving scope via using statement, instead of relying on the FileEntry finalizer.

Also updates dependencies.