### PR TITLE
Update SharpCompress to 0.37.2

### DIFF
--- a/RecursiveExtractor/RecursiveExtractor.csproj
+++ b/RecursiveExtractor/RecursiveExtractor.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="NLog" Version="5.2.8" />
-    <PackageReference Include="SharpCompress" Version="0.36.0" />
+    <PackageReference Include="SharpCompress" Version="0.37.2" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>


### PR DESCRIPTION
Update SharpCompress to 0.37.2

0.37.1 Contains an important fix for an infinite loop while processing corrupt tar files.

https://github.com/adamhathcock/sharpcompress/releases/tag/0.37.0
https://github.com/adamhathcock/sharpcompress/releases/tag/0.37.1
https://github.com/adamhathcock/sharpcompress/releases/tag/0.37.2