### PR TITLE
Improve reliability of CliTests by deferring cleanup to class cleanup

### DIFF
--- a/RecursiveExtractor.Cli.Tests/CliTests/CliTests.cs
+++ b/RecursiveExtractor.Cli.Tests/CliTests/CliTests.cs
@@ -13,7 +13,7 @@ using System.Threading;
 namespace RecursiveExtractor.Tests.CliTests
 {
     [TestClass]
-    public class CliTests
+    public class CliTests : BaseExtractorTestClass
     {
         [DataTestMethod]
         [DataRow("TestData.zip", 5)]
@@ -47,7 +47,6 @@ namespace RecursiveExtractor.Tests.CliTests
             if (Directory.Exists(directory))
             {
                 files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
-                Directory.Delete(directory, true);
             }
             Assert.AreEqual(expectedNumFiles, files.Length);
         }
@@ -96,7 +95,6 @@ namespace RecursiveExtractor.Tests.CliTests
             if (Directory.Exists(directory))
             {
                 files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
-                Directory.Delete(directory, true);
             }
             Assert.AreEqual(expectedNumFiles, files.Length);
         }
@@ -123,7 +121,6 @@ namespace RecursiveExtractor.Tests.CliTests
             if (Directory.Exists(directory))
             {
                 files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
-                Directory.Delete(directory, true);
             }
             Assert.AreEqual(expectedNumFiles, files.Length);
         }
@@ -138,19 +135,8 @@ namespace RecursiveExtractor.Tests.CliTests
             var path = Path.Combine(Directory.GetCurrentDirectory(), "TestData", "TestDataArchives", fileName);
             var passwords = EncryptedArchiveTests.TestArchivePasswords.Values.SelectMany(x => x);
             RecursiveExtractorClient.ExtractCommand(new ExtractCommandOptions() { Input = path, Output = directory, Verbose = true, Passwords = passwords });
-            var files = Array.Empty<string>();
-            if (Directory.Exists(directory))
-            {
-                files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
-                Directory.Delete(directory, true);
-            }
+            string[] files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
             Assert.AreEqual(expectedNumFiles, files.Length);
-        }
-
-        [ClassCleanup]
-        public static void ClassCleanup()
-        {
-            TestPathHelpers.DeleteTestDirectory();
         }
         
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();

--- a/RecursiveExtractor.Tests/ExtractorTests/ExpectedNumFilesTests.cs
+++ b/RecursiveExtractor.Tests/ExtractorTests/ExpectedNumFilesTests.cs
@@ -112,7 +112,6 @@ namespace RecursiveExtractor.Tests.ExtractorTests
             if (Directory.Exists(directory))
             {
                 files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
-                Directory.Delete(directory, true);
             }
             Assert.AreEqual(expectedNumFiles, files.Length);
         }
@@ -129,7 +128,6 @@ namespace RecursiveExtractor.Tests.ExtractorTests
             if (Directory.Exists(directory))
             {
                 files = Directory.EnumerateFiles(directory, "*.*", SearchOption.AllDirectories).ToArray();
-                Directory.Delete(directory, true);
             }
             Assert.AreEqual(expectedNumFiles, files.Length);
         }

--- a/RecursiveExtractor.Tests/TestPathHelpers.cs
+++ b/RecursiveExtractor.Tests/TestPathHelpers.cs
@@ -1,27 +1,37 @@
 ﻿using System;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 
 namespace Microsoft.CST.RecursiveExtractor.Tests;
 
 public static class TestPathHelpers
 {
     public const string TestTempFolderName = "RE_Tests";
+
+    public static string TestDirectoryPath => Path.Combine(Path.GetTempPath(), TestTempFolderName);
     
     public static string GetFreshTestDirectory()
     {
-        return Path.Combine(Path.GetTempPath(), TestTempFolderName, FileEntry.SanitizePath(DateTime.Now.ToString("yyMMdd_hhmmss_fffffff")));
+        return Path.Combine(TestDirectoryPath, FileEntry.SanitizePath(DateTime.Now.ToString("yyMMdd_hhmmss_fffffff")));
     }
 
     public static void DeleteTestDirectory()
     {
         try
         {
-            Directory.Delete(Path.Combine(Path.GetTempPath(), TestTempFolderName), true);
+            Directory.Delete(Path.Combine(TestDirectoryPath), true);
         }
         catch (DirectoryNotFoundException)
         {
             // Not an error. Not every test makes the folder.
         }
+        catch (Exception e)
+        {
+            // Throwing the exception up may cause tests to fail due to file system oddness so just log
+            Logger.Warn("Failed to delete Test Working Directory at {directory}", TestDirectoryPath);
+        }
     }
+    
+    static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
 }


### PR DESCRIPTION
Removes the `Directory.Delete` calls in each test case and instead uses `BaseExtractorTestClass` which cleans up the whole test scratch folder. Also adds better exception catching in `DeleteTestDirectory`. Aiming to improve test reliability in the pipelines.