### PR TITLE
Update NuGet package versions across projects

### DIFF
--- a/RecursiveExtractor.Cli.Tests/RecursiveExtractor.Cli.Tests.csproj
+++ b/RecursiveExtractor.Cli.Tests/RecursiveExtractor.Cli.Tests.csproj
@@ -11,8 +11,8 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
-        <PackageReference Include="MSTest" Version="3.9.3" />
+        <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.4" />
+        <PackageReference Include="MSTest" Version="3.10.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/RecursiveExtractor.Cli/RecursiveExtractor.Cli.csproj
+++ b/RecursiveExtractor.Cli/RecursiveExtractor.Cli.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.1" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.3" />
   </ItemGroup>
  
   <ItemGroup>

--- a/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
+++ b/RecursiveExtractor.Tests/RecursiveExtractor.Tests.csproj
@@ -9,14 +9,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.SquashFs" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.61" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.1" />
+    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.SquashFs" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.64" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.0.3" />
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
-    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.3" />
-    <PackageReference Include="MSTest" Version="3.9.3" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.8.4" />
+    <PackageReference Include="MSTest" Version="3.10.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 

--- a/RecursiveExtractor/RecursiveExtractor.csproj
+++ b/RecursiveExtractor/RecursiveExtractor.csproj
@@ -25,23 +25,23 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Core" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Ext" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Fat" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Iso9660" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Ntfs" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Udf" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Vhd" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Vhdx" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Vmdk" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Wim" Version="1.0.61" />
-    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.61" />
+    <PackageReference Include="LTRData.DiscUtils.Btrfs" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Core" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Ext" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Fat" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.HfsPlus" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Iso9660" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Ntfs" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Udf" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Vhd" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Vhdx" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Vmdk" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Wim" Version="1.0.64" />
+    <PackageReference Include="LTRData.DiscUtils.Xfs" Version="1.0.64" />
     <PackageReference Include="Glob" Version="1.1.9" />
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.7" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.8" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="NLog" Version="6.0.1" />
+    <PackageReference Include="NLog" Version="6.0.3" />
     <PackageReference Include="SharpCompress" Version="0.40.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.3" />
   </ItemGroup>


### PR DESCRIPTION
Upgraded various package dependencies in all project files, including LTRData.DiscUtils, NLog, MSTest, and Microsoft.Testing.Extensions.TrxReport, to their latest versions. This ensures improved compatibility, security, and access to new features.