### PR TITLE
Improve ZipSlip sanitization and output-dir checks

### DIFF
--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -139,18 +139,18 @@ namespace RecursiveExtractor.Tests
             var child = new FileEntry("/etc/cron.d/evil", Stream.Null, parent);
             Assert.False(Path.IsPathRooted(child.FullPath),
                 $"FullPath should be relative but was: {child.FullPath}");
-            Assert.DoesNotContain("..", child.FullPath);
+            AssertNoTraversalSegments(child.FullPath);
         }
 
         /// <summary>
-        /// FileEntry.FullPath should not contain ".." even when the entry name has traversal.
+        /// FileEntry.FullPath should not contain ".." path segments even when the entry name has traversal.
         /// </summary>
         [Fact]
         public void TestFileEntry_TraversalEntryName_Sanitized()
         {
             var parent = new FileEntry("archive.tar", Stream.Null);
             var child = new FileEntry("../../../etc/passwd", Stream.Null, parent);
-            Assert.DoesNotContain("..", child.FullPath);
+            AssertNoTraversalSegments(child.FullPath);
         }
 
         /// <summary>
@@ -163,6 +163,15 @@ namespace RecursiveExtractor.Tests
             var child = new FileEntry("\\Windows\\System32\\evil.dll", Stream.Null, parent);
             Assert.False(Path.IsPathRooted(child.FullPath),
                 $"FullPath should be relative but was: {child.FullPath}");
+        }
+
+        /// <summary>
+        /// Assert that no path segment is exactly ".." (ignoring ".." as a substring in filenames like "file..txt").
+        /// </summary>
+        private static void AssertNoTraversalSegments(string path)
+        {
+            var segments = path.Split(Path.DirectorySeparatorChar);
+            Assert.DoesNotContain("..", segments);
         }
 
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();

--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -121,6 +121,8 @@ namespace RecursiveExtractor.Tests
         [InlineData("file..txt", "file..txt")]
         [InlineData("my..archive/data..bin", "my..archive/data..bin")]
         [InlineData("a/./b", "a/b")]
+        [InlineData("a:file.txt", "a:file.txt")]
+        [InlineData("a:folder/file.txt", "a:folder/file.txt")]
         public void TestZipSlipSanitize_SafePathsUnchanged(string input, string expected)
         {
             expected = expected.Replace('/', Path.DirectorySeparatorChar);

--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -60,6 +60,7 @@ namespace RecursiveExtractor.Tests
         [InlineData("D:/data/file.txt", "data/file.txt")]
         [InlineData("C:\\", "")]
         [InlineData("C:/", "")]
+        [InlineData("a:file.txt", "a:file.txt")]
         public void TestZipSlipSanitize_AbsoluteWindowsPaths(string input, string expected)
         {
             expected = expected.Replace('/', Path.DirectorySeparatorChar);

--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -35,6 +35,131 @@ namespace RecursiveExtractor.Tests
             }
         }
 
+        /// <summary>
+        /// ZipSlipSanitize should strip leading slashes to prevent absolute path traversal.
+        /// On any OS, a Unix-style absolute path like "/etc/passwd" must become relative.
+        /// </summary>
+        [Theory]
+        [InlineData("/etc/passwd", "etc/passwd")]
+        [InlineData("/tmp/evil.txt", "tmp/evil.txt")]
+        [InlineData("///triple/leading", "triple/leading")]
+        [InlineData("/", "")]
+        public void TestZipSlipSanitize_AbsoluteUnixPaths(string input, string expected)
+        {
+            // Normalize expected to the current OS separator
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// ZipSlipSanitize should strip Windows drive letter roots.
+        /// </summary>
+        [Theory]
+        [InlineData("C:\\Windows\\System32\\evil.dll", "Windows/System32/evil.dll")]
+        [InlineData("D:/data/file.txt", "data/file.txt")]
+        [InlineData("C:\\", "")]
+        [InlineData("C:/", "")]
+        public void TestZipSlipSanitize_AbsoluteWindowsPaths(string input, string expected)
+        {
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// ZipSlipSanitize should strip ".." directory traversal components.
+        /// </summary>
+        [Theory]
+        [InlineData("foo/../../../etc/passwd", "foo/etc/passwd")]
+        [InlineData("../secret.txt", "secret.txt")]
+        [InlineData("a/b/../../c", "a/b/c")]
+        public void TestZipSlipSanitize_DotDotTraversal(string input, string expected)
+        {
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// ZipSlipSanitize should handle combined absolute + traversal attacks.
+        /// After ".." is stripped, exposed leading separators are also stripped.
+        /// </summary>
+        [Theory]
+        [InlineData("/../../etc/passwd", "etc/passwd")]
+        [InlineData("C:\\..\\..\\Windows\\evil.dll", "Windows/evil.dll")]
+        [InlineData("/../../../tmp/evil", "tmp/evil")]
+        public void TestZipSlipSanitize_CombinedAbsoluteAndTraversal(string input, string expected)
+        {
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// ZipSlipSanitize should collapse double separators that result from stripping.
+        /// </summary>
+        [Theory]
+        [InlineData("a/../b", "a/b")]
+        [InlineData("a/../../b", "a/b")]
+        public void TestZipSlipSanitize_CollapsesDoubleSeparators(string input, string expected)
+        {
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// Safe relative paths should pass through unmodified.
+        /// </summary>
+        [Theory]
+        [InlineData("normal/path/file.txt", "normal/path/file.txt")]
+        [InlineData("file.txt", "file.txt")]
+        [InlineData("a/b/c/d.txt", "a/b/c/d.txt")]
+        public void TestZipSlipSanitize_SafePathsUnchanged(string input, string expected)
+        {
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
+        /// FileEntry.FullPath should never be absolute when constructed with a parent,
+        /// even if the entry name is an absolute path.
+        /// </summary>
+        [Fact]
+        public void TestFileEntry_AbsoluteEntryName_BecomesRelative()
+        {
+            var parent = new FileEntry("archive.zip", Stream.Null);
+            var child = new FileEntry("/etc/cron.d/evil", Stream.Null, parent);
+            Assert.False(Path.IsPathRooted(child.FullPath),
+                $"FullPath should be relative but was: {child.FullPath}");
+            Assert.DoesNotContain("..", child.FullPath);
+        }
+
+        /// <summary>
+        /// FileEntry.FullPath should not contain ".." even when the entry name has traversal.
+        /// </summary>
+        [Fact]
+        public void TestFileEntry_TraversalEntryName_Sanitized()
+        {
+            var parent = new FileEntry("archive.tar", Stream.Null);
+            var child = new FileEntry("../../../etc/passwd", Stream.Null, parent);
+            Assert.DoesNotContain("..", child.FullPath);
+        }
+
+        /// <summary>
+        /// Backslash-rooted paths should also be made relative.
+        /// </summary>
+        [Fact]
+        public void TestFileEntry_BackslashRooted_BecomesRelative()
+        {
+            var parent = new FileEntry("archive.zip", Stream.Null);
+            var child = new FileEntry("\\Windows\\System32\\evil.dll", Stream.Null, parent);
+            Assert.False(Path.IsPathRooted(child.FullPath),
+                $"FullPath should be relative but was: {child.FullPath}");
+        }
+
         protected static readonly NLog.Logger Logger = NLog.LogManager.GetCurrentClassLogger();
     }
 }

--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -69,6 +69,25 @@ namespace RecursiveExtractor.Tests
         }
 
         /// <summary>
+        /// ZipSlipSanitize should recursively strip nested roots that are exposed after each strip.
+        /// A single pass is insufficient for crafted paths like "D:\C:\" (stripping D: exposes \C:\),
+        /// or paths starting with multiple separators like "\\C:\" (stripping both leading separators
+        /// exposes C:\), or "../C:\file" where removing ".." exposes C:\file.
+        /// </summary>
+        [Theory]
+        [InlineData("D:\\C:\\file.txt", "file.txt")]
+        [InlineData("\\\\C:\\file.txt", "file.txt")]
+        [InlineData("..\\C:\\file.txt", "file.txt")]
+        [InlineData("D:/C:/file.txt", "file.txt")]
+        [InlineData("D:\\C:\\D:\\file.txt", "file.txt")]
+        public void TestZipSlipSanitize_NestedRoots(string input, string expected)
+        {
+            expected = expected.Replace('/', Path.DirectorySeparatorChar);
+            var result = FileEntry.ZipSlipSanitize(input);
+            Assert.Equal(expected, result);
+        }
+
+        /// <summary>
         /// ZipSlipSanitize should strip ".." directory traversal components.
         /// </summary>
         [Theory]

--- a/RecursiveExtractor.Tests/SanitizePathTests.cs
+++ b/RecursiveExtractor.Tests/SanitizePathTests.cs
@@ -111,11 +111,15 @@ namespace RecursiveExtractor.Tests
 
         /// <summary>
         /// Safe relative paths should pass through unmodified.
+        /// Filenames containing ".." as a substring (not a path segment) must be preserved.
         /// </summary>
         [Theory]
         [InlineData("normal/path/file.txt", "normal/path/file.txt")]
         [InlineData("file.txt", "file.txt")]
         [InlineData("a/b/c/d.txt", "a/b/c/d.txt")]
+        [InlineData("file..txt", "file..txt")]
+        [InlineData("my..archive/data..bin", "my..archive/data..bin")]
+        [InlineData("a/./b", "a/b")]
         public void TestZipSlipSanitize_SafePathsUnchanged(string input, string expected)
         {
             expected = expected.Replace('/', Path.DirectorySeparatorChar);

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -495,9 +495,16 @@ namespace Microsoft.CST.RecursiveExtractor
             opts ??= new ExtractorOptions();
             if (!opts.Parallel)
             {
+                var fullOutputDir = Path.GetFullPath(outputDirectory) + Path.DirectorySeparatorChar;
                 foreach (var entry in Extract(fileEntry, opts))
                 {
                     var targetPath = Path.Combine(outputDirectory, entry.GetSanitizedPath());
+                    var fullTargetPath = Path.GetFullPath(targetPath);
+                    if (!fullTargetPath.StartsWith(fullOutputDir, StringComparison.Ordinal))
+                    {
+                        Logger.Warn("Skipping entry that would escape output directory: {0}", entry.FullPath);
+                        continue;
+                    }
                     if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {
                         try
@@ -537,6 +544,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     using var enumerator = extractedEnumeration.GetEnumerator();
                     // Move to the first element to prepare
                     ConcurrentBag<FileEntry> entryBatch = new();
+                    var parallelFullOutputDir = Path.GetFullPath(outputDirectory) + Path.DirectorySeparatorChar;
                     bool moreAvailable = enumerator.MoveNext();
                     while (moreAvailable)
                     {
@@ -559,6 +567,12 @@ namespace Microsoft.CST.RecursiveExtractor
                         Parallel.ForEach(entryBatch, new ParallelOptions() { CancellationToken = cts.Token }, entry =>
                         {
                             var targetPath = Path.Combine(outputDirectory, entry.GetSanitizedPath());
+                            var fullTargetPath = Path.GetFullPath(targetPath);
+                            if (!fullTargetPath.StartsWith(parallelFullOutputDir, StringComparison.Ordinal))
+                            {
+                                Logger.Warn("Skipping entry that would escape output directory: {0}", entry.FullPath);
+                                return;
+                            }
 
                             if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                             {
@@ -645,11 +659,18 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public async Task<ExtractionStatusCode> ExtractToDirectoryAsync(string outputDirectory, FileEntry fileEntry, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
+            var asyncFullOutputDir = Path.GetFullPath(outputDirectory) + Path.DirectorySeparatorChar;
             await foreach (var entry in ExtractAsync(fileEntry, opts))
             {
                 if (opts?.FileNamePasses(entry.FullPath) ?? true)
                 {
                     var targetPath = Path.Combine(outputDirectory, entry.GetSanitizedPath());
+                    var fullTargetPath = Path.GetFullPath(targetPath);
+                    if (!fullTargetPath.StartsWith(asyncFullOutputDir, StringComparison.Ordinal))
+                    {
+                        Logger.Warn("Skipping entry that would escape output directory: {0}", entry.FullPath);
+                        continue;
+                    }
 
                     if (Path.GetDirectoryName(targetPath) is { } directoryPathNotNull && targetPath is { } targetPathNotNull)
                     {

--- a/RecursiveExtractor/Extractor.cs
+++ b/RecursiveExtractor/Extractor.cs
@@ -495,7 +495,7 @@ namespace Microsoft.CST.RecursiveExtractor
             opts ??= new ExtractorOptions();
             if (!opts.Parallel)
             {
-                var fullOutputDir = Path.GetFullPath(outputDirectory) + Path.DirectorySeparatorChar;
+                var fullOutputDir = Path.GetFullPath(outputDirectory).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
                 foreach (var entry in Extract(fileEntry, opts))
                 {
                     var targetPath = Path.Combine(outputDirectory, entry.GetSanitizedPath());
@@ -544,7 +544,7 @@ namespace Microsoft.CST.RecursiveExtractor
                     using var enumerator = extractedEnumeration.GetEnumerator();
                     // Move to the first element to prepare
                     ConcurrentBag<FileEntry> entryBatch = new();
-                    var parallelFullOutputDir = Path.GetFullPath(outputDirectory) + Path.DirectorySeparatorChar;
+                    var parallelFullOutputDir = Path.GetFullPath(outputDirectory).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
                     bool moreAvailable = enumerator.MoveNext();
                     while (moreAvailable)
                     {
@@ -659,7 +659,7 @@ namespace Microsoft.CST.RecursiveExtractor
         /// <param name="printNames">If we should print the filename when writing it out to disc.</param>
         public async Task<ExtractionStatusCode> ExtractToDirectoryAsync(string outputDirectory, FileEntry fileEntry, ExtractorOptions? opts = null, IEnumerable<Regex>? acceptFilters = null, IEnumerable<Regex>? denyFilters = null, bool printNames = false)
         {
-            var asyncFullOutputDir = Path.GetFullPath(outputDirectory) + Path.DirectorySeparatorChar;
+            var asyncFullOutputDir = Path.GetFullPath(outputDirectory).TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar;
             await foreach (var entry in ExtractAsync(fileEntry, opts))
             {
                 if (opts?.FileNamePasses(entry.FullPath) ?? true)

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -40,8 +40,10 @@ namespace Microsoft.CST.RecursiveExtractor
             ModifyTime = modifyTime ?? DateTime.MinValue;
             AccessTime = accessTime ?? DateTime.MinValue;
 
-            // Sanitize so its safe to use with Path APIs
-            string sanitizedName = SanitizePath(name);
+            // Sanitize traversal and absolute paths first while path structure is intact
+            string zipSlipSafeName = ZipSlipSanitize(name);
+            // Then replace any remaining OS-invalid characters
+            string sanitizedName = SanitizePath(zipSlipSafeName);
             Name = Path.GetFileName(sanitizedName);
 
             // If parent is null use the provided name as the FullPath

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -322,23 +322,28 @@ namespace Microsoft.CST.RecursiveExtractor
                 fullPath = fullPath.Substring(1);
             }
 
-            if (fullPath.Contains(".."))
+            if (fullPath.Length > 0)
             {
-                fullPath = fullPath.Replace("..", replacement);
+                var separator = Path.DirectorySeparatorChar;
+                var segments = fullPath.Split(separator);
+
+                for (var i = 0; i < segments.Length; i++)
+                {
+                    // Replace traversal segments (".." and ".") only when they are whole segments
+                    if (segments[i] == ".." || segments[i] == ".")
+                    {
+                        segments[i] = replacement;
+                    }
+                }
+
+                // Rebuild the path from non-empty segments
+                fullPath = string.Join(separator.ToString(), segments.Where(s => !string.IsNullOrEmpty(s)));
             }
 
-            // Strip leading separators again (removal of ".." can expose them, e.g. "../x" → "/x")
+            // Strip leading separators again (removal of segments can expose them)
             while (fullPath.Length > 0 && fullPath[0] == Path.DirectorySeparatorChar)
             {
                 fullPath = fullPath.Substring(1);
-            }
-
-            // Collapse double separators (can result from .. removal or root stripping)
-            var directorySeparator = Path.DirectorySeparatorChar.ToString();
-            var doubleSeparator = $"{directorySeparator}{directorySeparator}";
-            while (fullPath.Contains(doubleSeparator))
-            {
-                fullPath = fullPath.Replace(doubleSeparator, directorySeparator);
             }
 
             return fullPath;

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -310,8 +310,11 @@ namespace Microsoft.CST.RecursiveExtractor
             // Normalize all separators to the OS-native separator
             fullPath = fullPath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
-            // Strip Windows drive letter roots (e.g., "C:\", "D:/")
-            if (fullPath.Length >= 2 && char.IsLetter(fullPath[0]) && fullPath[1] == ':')
+            // Strip Windows drive letter roots (e.g., "C:\", "D:/") but not relative names like "a:file.txt"
+            if (fullPath.Length >= 3
+                && char.IsLetter(fullPath[0])
+                && fullPath[1] == ':'
+                && fullPath[2] == Path.DirectorySeparatorChar)
             {
                 fullPath = fullPath.Substring(2);
             }

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -297,23 +297,48 @@ namespace Microsoft.CST.RecursiveExtractor
         }
 
         /// <summary>
-        /// Replace .. for ZipSlip and remove any doubled up directory separators as a result - https://snyk.io/research/zip-slip-vulnerability
+        /// Sanitize paths to prevent ZipSlip (directory traversal) and absolute path traversal.
+        /// Strips leading directory separators and drive letter roots, removes ".." sequences,
+        /// and collapses resulting double separators. See https://snyk.io/research/zip-slip-vulnerability
         /// </summary>
         /// <param name="fullPath">The path to sanitize</param>
         /// <param name="replacement">The string to replace .. with</param>
-        /// <returns>A path without ZipSlip</returns>
+        /// <returns>A relative path safe from directory traversal</returns>
         [Pure]
-        private static string ZipSlipSanitize(string fullPath, string replacement = "")
+        internal static string ZipSlipSanitize(string fullPath, string replacement = "")
         {
+            // Normalize all separators to the OS-native separator
+            fullPath = fullPath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
+
+            // Strip Windows drive letter roots (e.g., "C:\", "D:/")
+            if (fullPath.Length >= 2 && char.IsLetter(fullPath[0]) && fullPath[1] == ':')
+            {
+                fullPath = fullPath.Substring(2);
+            }
+
+            // Strip leading directory separators to prevent absolute path traversal
+            while (fullPath.Length > 0 && fullPath[0] == Path.DirectorySeparatorChar)
+            {
+                fullPath = fullPath.Substring(1);
+            }
+
             if (fullPath.Contains(".."))
             {
                 fullPath = fullPath.Replace("..", replacement);
-                var directorySeparator = Path.DirectorySeparatorChar.ToString();
-                var doubleSeparator = $"{directorySeparator},{directorySeparator}";
-                while (fullPath.Contains(doubleSeparator))
-                {
-                    fullPath = fullPath.Replace(doubleSeparator, $"{directorySeparator}");
-                }
+            }
+
+            // Strip leading separators again (removal of ".." can expose them, e.g. "../x" → "/x")
+            while (fullPath.Length > 0 && fullPath[0] == Path.DirectorySeparatorChar)
+            {
+                fullPath = fullPath.Substring(1);
+            }
+
+            // Collapse double separators (can result from .. removal or root stripping)
+            var directorySeparator = Path.DirectorySeparatorChar.ToString();
+            var doubleSeparator = $"{directorySeparator}{directorySeparator}";
+            while (fullPath.Contains(doubleSeparator))
+            {
+                fullPath = fullPath.Replace(doubleSeparator, directorySeparator);
             }
 
             return fullPath;

--- a/RecursiveExtractor/FileEntry.cs
+++ b/RecursiveExtractor/FileEntry.cs
@@ -312,20 +312,9 @@ namespace Microsoft.CST.RecursiveExtractor
             // Normalize all separators to the OS-native separator
             fullPath = fullPath.Replace('\\', Path.DirectorySeparatorChar).Replace('/', Path.DirectorySeparatorChar);
 
-            // Strip Windows drive letter roots (e.g., "C:\", "D:/") but not relative names like "a:file.txt"
-            if (fullPath.Length >= 3
-                && char.IsLetter(fullPath[0])
-                && fullPath[1] == ':'
-                && fullPath[2] == Path.DirectorySeparatorChar)
-            {
-                fullPath = fullPath.Substring(2);
-            }
-
-            // Strip leading directory separators to prevent absolute path traversal
-            while (fullPath.Length > 0 && fullPath[0] == Path.DirectorySeparatorChar)
-            {
-                fullPath = fullPath.Substring(1);
-            }
+            // Strip drive letter roots and leading separators. Must run before and after ".."
+            // removal because ".." removal can expose a new drive root (e.g. "../C:\file" → "C:\file").
+            fullPath = StripLeadingRootComponents(fullPath);
 
             if (fullPath.Length > 0)
             {
@@ -345,12 +334,41 @@ namespace Microsoft.CST.RecursiveExtractor
                 fullPath = string.Join(separator.ToString(), segments.Where(s => !string.IsNullOrEmpty(s)));
             }
 
-            // Strip leading separators again (removal of segments can expose them)
-            while (fullPath.Length > 0 && fullPath[0] == Path.DirectorySeparatorChar)
-            {
-                fullPath = fullPath.Substring(1);
-            }
+            fullPath = StripLeadingRootComponents(fullPath);
 
+            return fullPath;
+        }
+
+        /// <summary>
+        /// Repeatedly strips Windows drive letter roots (e.g. "C:\") and leading directory
+        /// separators until the path is stable. A single pass is insufficient for crafted paths
+        /// like "D:\C:\" where stripping "D:" exposes a new root "C:\".
+        /// </summary>
+        private static string StripLeadingRootComponents(string fullPath)
+        {
+            bool changed;
+            do
+            {
+                changed = false;
+
+                // Strip Windows drive letter roots (e.g., "C:\", "D:/") but not relative names like "a:file.txt"
+                if (fullPath.Length >= 3
+                    && char.IsLetter(fullPath[0])
+                    && fullPath[1] == ':'
+                    && fullPath[2] == Path.DirectorySeparatorChar)
+                {
+                    fullPath = fullPath.Substring(2);
+                    changed = true;
+                }
+
+                // Strip leading directory separators to prevent absolute path traversal
+                while (fullPath.Length > 0 && fullPath[0] == Path.DirectorySeparatorChar)
+                {
+                    fullPath = fullPath.Substring(1);
+                    changed = true;
+                }
+            }
+            while (changed);
             return fullPath;
         }
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
     <clear />


### PR DESCRIPTION
Strengthen path sanitization and guard extraction from directory escape. FileEntry.ZipSlipSanitize was made internal and enhanced to normalize separators, strip Windows drive roots and leading separators, remove ".." sequences, and collapse double separators. Extractor now resolves full target paths and ensures they start with the resolved output directory (sync, parallel, and async extraction), skipping and logging entries that would escape. Added comprehensive unit tests (SanitizePathTests) covering absolute paths, drive roots, traversal, combined attacks, separator collapsing, and FileEntry behavior.